### PR TITLE
Remove setValue() from hide()

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -226,7 +226,6 @@
 					this.hasInput && this.element.find('input').val()
 				)
 			)
-				this.setValue();
 			this.element.trigger({
 				type: 'hide',
 				date: this.date


### PR DESCRIPTION
When the calendar is blurred, it shouldn't set the value to the date that is selected.