### PR TITLE
Fix for strange scrolling behavior in modal

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -237,7 +237,7 @@
 
 		show: function(e) {
 			if (!this.isInline)
-				this.picker.appendTo('body');
+				this.picker.appendTo(this.element);
 			this.picker.show();
 			this.height = this.component ? this.component.outerHeight() : this.element.outerHeight();
 			this.place();
@@ -354,7 +354,7 @@
 			var zIndex = parseInt(this.element.parents().filter(function() {
 							return $(this).css('z-index') != 'auto';
 						}).first().css('z-index'))+10;
-			var offset = this.component ? this.component.parent().offset() : this.element.offset();
+			var offset = this.component ? this.component.parent().position() : this.element.offset();
 			var height = this.component ? this.component.outerHeight(true) : this.element.outerHeight(true);
 			this.picker.css({
 				top: offset.top + height,


### PR DESCRIPTION
Placing a datepicker as a component in a bootstrap modal would bind to
the body rather than the element of the modal. This would cause the
datepicker to scroll with the body while the modal remained in place.
This patch binds the datepicker dropdown to the element where it was
invoked and changes the computation of the offset to use position(),
since offset() was relative to the window. Fixes #325.