### PR TITLE
datesDisable option

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -27,6 +27,11 @@
 		var today = new Date();
 		return UTCDate(today.getUTCFullYear(), today.getUTCMonth(), today.getUTCDate());
 	}
+	function isUTCEquals(date1, date2) {
+		return (	date1.getUTCFullYear() === date2.getUTCFullYear() && 
+					date1.getUTCMonth() === date2.getUTCMonth() && 
+					date1.getUTCDate() === date2.getUTCDate() );
+	}
 
 	// Picker object
 
@@ -150,6 +155,15 @@
 				o.daysOfWeekDisabled = o.daysOfWeekDisabled.split(/[,\s]*/);
 			o.daysOfWeekDisabled = $.map(o.daysOfWeekDisabled, function (d) {
 				return parseInt(d, 10);
+			});
+
+			o.datesDisabled = o.datesDisabled||[];
+			if (!$.isArray(o.datesDisabled)) {
+				o.datesDisabled = [];
+				o.datesDisabled.push( DPGlobal.parseDate(o.datesDisabled, format, o.language) );
+			}
+			o.datesDisabled = $.map(o.datesDisabled, function (d) {
+				return DPGlobal.parseDate(d, format, o.language);
 			});
 		},
 		_events: [],
@@ -348,6 +362,12 @@
 			this.updateNavArrows();
 		},
 
+		setDatesDisabled: function(datesDisabled){
+			this._process_options({datesDisabled: datesDisabled});
+			this.update();
+			this.updateNavArrows();
+		},
+
 		place: function(){
 						if(this.isInline) return;
 			var zIndex = parseInt(this.element.parents().filter(function() {
@@ -446,6 +466,11 @@
 				$.inArray(date.getUTCDay(), this.o.daysOfWeekDisabled) !== -1) {
 				cls.push('disabled');
 			}
+			if ( this.o.datesDisabled.length > 0 && 
+				 $.grep(this.o.datesDisabled, function(d) { return isUTCEquals(date, d); }).length > 0 ) {
+				cls.push('disabled');
+			}
+
 			if (this.range){
 				if (date > this.range[0] && date < this.range[this.range.length-1]){
 					cls.push('range');

--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -78,6 +78,7 @@
 		this.setStartDate(this.o.startDate);
 		this.setEndDate(this.o.endDate);
 		this.setDaysOfWeekDisabled(this.o.daysOfWeekDisabled);
+		this.setDatesDisabled(this.o.datesDisabled);
 
 		this.fillDow();
 		this.fillMonths();
@@ -468,7 +469,7 @@
 			}
 			if ( this.o.datesDisabled.length > 0 && 
 				 $.grep(this.o.datesDisabled, function(d) { return isUTCEquals(date, d); }).length > 0 ) {
-				cls.push('disabled');
+				cls.push('disabled', 'disabled-date');
 			}
 
 			if (this.range){
@@ -1027,6 +1028,7 @@
 		calendarWeeks: false,
 		clearBtn: false,
 		daysOfWeekDisabled: [],
+		datesDisabled: [],
 		endDate: Infinity,
 		forceParse: true,
 		format: 'mm/dd/yyyy',

--- a/tests/suites/options.js
+++ b/tests/suites/options.js
@@ -375,14 +375,17 @@ test('DatesDisabled', function(){
 
     target = picker.find('.datepicker-days tbody td:nth(1)');
     ok(target.hasClass('disabled'), 'Day of week is disabled');
+    ok(target.hasClass('disabled-date'), 'Date is disabled');
     target = picker.find('.datepicker-days tbody td:nth(2)');
     ok(!target.hasClass('disabled'), 'Day of week is enabled');
     target = picker.find('.datepicker-days tbody td:nth(10)');
     ok(target.hasClass('disabled'), 'Day of week is disabled');
+    ok(target.hasClass('disabled-date'), 'Date is disabled');
     target = picker.find('.datepicker-days tbody td:nth(11)');
     ok(!target.hasClass('disabled'), 'Day of week is enabled');
     target = picker.find('.datepicker-days tbody td:nth(20)');
     ok(target.hasClass('disabled'), 'Day of week is disabled');
+    ok(target.hasClass('disabled-date'), 'Date is disabled');
     target = picker.find('.datepicker-days tbody td:nth(21)');
     ok(!target.hasClass('disabled'), 'Day of week is enabled');
 });

--- a/tests/suites/options.js
+++ b/tests/suites/options.js
@@ -357,6 +357,36 @@ test('DaysOfWeekDisabled', function(){
     ok(target.hasClass('disabled'), 'Day of week is disabled');
 });
 
+
+test('DatesDisabled', function(){
+    var input = $('<input />')
+                .appendTo('#qunit-fixture')
+                .val('2012-10-26')
+                .datepicker({
+                    format: 'yyyy-mm-dd',
+                    datesDisabled: ['2012-10-1', '2012-10-10', '2012-10-20']
+                }),
+        dp = input.data('datepicker'),
+        picker = dp.picker,
+        target;
+
+
+    input.focus();
+
+    target = picker.find('.datepicker-days tbody td:nth(1)');
+    ok(target.hasClass('disabled'), 'Day of week is disabled');
+    target = picker.find('.datepicker-days tbody td:nth(2)');
+    ok(!target.hasClass('disabled'), 'Day of week is enabled');
+    target = picker.find('.datepicker-days tbody td:nth(10)');
+    ok(target.hasClass('disabled'), 'Day of week is disabled');
+    target = picker.find('.datepicker-days tbody td:nth(11)');
+    ok(!target.hasClass('disabled'), 'Day of week is enabled');
+    target = picker.find('.datepicker-days tbody td:nth(20)');
+    ok(target.hasClass('disabled'), 'Day of week is disabled');
+    target = picker.find('.datepicker-days tbody td:nth(21)');
+    ok(!target.hasClass('disabled'), 'Day of week is enabled');
+});
+
 test('BeforeShowDay', function(){
 
     var beforeShowDay = function(date) {


### PR DESCRIPTION
An array to specify dates to disable. It also adds the .disabled-date class in order to customise the UI.

Usage:

```javascript
var input = $('<input />').datepicker({
                    format: 'yyyy-mm-dd',
                    datesDisabled: ['2012-10-1', '2012-10-10', '2012-10-20']
                }),
```