### PR TITLE
Added maxViewMode to options

### DIFF
--- a/docs/options.rst
+++ b/docs/options.rst
@@ -121,6 +121,13 @@ Number, String.  Default: 0, "days"
 Set a limit for the view mode.  Accepts: "days" or 0, "months" or 1, and "years" or 2.
 Gives the ability to pick only a month or an year.  The day is set to the 1st for "months", and the month is set to January for "years".
 
+maxViewMode
+-----------
+
+Number, String.  Default: 2, "years"
+
+Set a limit for the view mode.  Accepts: "days" or 0, "months" or 1, and "years" or 2.
+Gives the ability to pick only a day or a month. If minViewMode is greater than maxViewMode maxViewMode will be ignored.
 
 orientation
 -----------

--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -137,6 +137,20 @@
 					o.minViewMode = 0;
 			}
 
+			switch (o.maxViewMode) {
+				case 0:
+				case 'days':
+					o.maxViewMode = 0;
+					break;
+				case 1:
+				case 'months':
+					o.maxViewMode = 1;
+					break;
+				default:
+					o.maxViewMode = 2;
+			}
+
+			o.startView = Math.min(o.startView, o.maxViewMode);
 			o.startView = Math.max(o.startView, o.minViewMode);
 
 			o.weekStart %= 7;
@@ -998,7 +1012,7 @@
 
 		showMode: function(dir) {
 			if (dir) {
-				this.viewMode = Math.max(this.o.minViewMode, Math.min(2, this.viewMode + dir));
+				this.viewMode = Math.max(this.o.minViewMode, Math.min(2, this.viewMode + dir, this.o.maxViewMode));
 			}
 			/*
 				vitalets: fixing bug of very special conditions:
@@ -1147,6 +1161,7 @@
 		keyboardNavigation: true,
 		language: 'en',
 		minViewMode: 0,
+		maxViewMode: 2,
 		orientation: "auto",
 		rtl: false,
 		startDate: -Infinity,


### PR DESCRIPTION
We've added a maxViewMode to accompany the minViewMode option.

This allow you to prevent people selecting by year or month.