### PR TITLE
Datepicker range selector reset creates a visual problem --- FIX.

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -502,6 +502,7 @@
 				this.date = new Date(this.date);
 			} else {
 				this.date = undefined;
+				this.range = undefined;
 			}
 
 			if (fromArgs) {


### PR DESCRIPTION
When clearing values for a datepicker range, it does not clear the previous selection causing a visual UX error due to code in [getClassNames](https://github.com/eternicode/bootstrap-datepicker/blob/master/js/bootstrap-datepicker.js#L578-L585). See [screenshot](https://www.evernote.com/shard/s310/sh/d9dcefca-8441-4837-a6ea-257150432bab/cb05fb7bbb84a42732df4f02976e8657) of issue. 

Adding the committed line of code  `this.range = undefined;` solves this issue.