### PR TITLE
Using {todayBtn: true} trigger changeDate

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -1006,7 +1006,9 @@
 
 			this.fill();
 			this.setValue();
-			this._trigger('changeDate');
+			if (!which || which  !== 'view') {
+				this._trigger('changeDate');
+			}
 			var element;
 			if (this.isInput) {
 				element = this.element;


### PR DESCRIPTION
when I use the "today" button with the setting {todayBtn: true}. This should not trigger the event changeDate, because the date in the input field does not change. It changes only with {todayBtn: "linked"}. In _setDate check if (which !== 'view')