### PR TITLE
If the input field has the disabled attribute the datepicker won't show

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -93,8 +93,9 @@
 		this.element = $(element);
 		this.isInline = false;
 		this.isInput = this.element.is('input');
+		this.inputField = this.isInput ? this.element : this.element.find('input');
 		this.component = this.element.is('.date') ? this.element.find('.add-on, .input-group-addon, .btn') : false;
-		this.hasInput = this.component && this.element.find('input').length;
+		this.hasInput = this.component && this.inputField.length;
 		if (this.component && this.component.length === 0)
 			this.component = false;
 
@@ -309,7 +310,7 @@
 			else if (this.component && this.hasInput){ // component: input + button
 				this._events = [
 					// For components that are not readonly, allow keyboard nav
-					[this.element.find('input'), {
+					[this.inputField, {
 						focus: $.proxy(this.show, this),
 						keyup: $.proxy(function(e){
 							if ($.inArray(e.keyCode, [27,37,39,38,40,32,13,9]) === -1)
@@ -407,13 +408,20 @@
 			});
 		},
 
+		enable: function(){
+			this.inputField.prop('disabled', false);
+		},
+
 		show: function(){
-			if (!this.isInline)
-				this.picker.appendTo('body');
-			this.picker.show();
-			this.place();
-			this._attachSecondaryEvents();
-			this._trigger('show');
+			// if the input is not disabled we can display the datepicker
+			if(!this.inputField.prop('disabled')){
+				if (!this.isInline)
+					this.picker.appendTo('body');
+				this.picker.show();
+				this.place();
+				this._attachSecondaryEvents();
+				this._trigger('show');
+			}
 		},
 
 		hide: function(){

--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -408,13 +408,9 @@
 			});
 		},
 
-		enable: function(){
-			this.inputField.prop('disabled', false);
-		},
-
 		show: function(){
 			// if the input is not disabled we can display the datepicker
-			if(!this.inputField.prop('disabled')){
+			if (!this.inputField.prop('disabled')){
 				if (!this.isInline)
 					this.picker.appendTo('body');
 				this.picker.show();


### PR DESCRIPTION
In both situations:
```html
<div class="input-group date" id="from" data-date-format="dd/mm/yyyy">
	<input class="form-control" size="16" type="text" name="start_date" id="start_date" required disabled>
	<div class="input-group-addon">
		<span class="glyphicon glyphicon-calendar"></span>
	</div>
</div>
```

```html
<input class="form-control" size="16" type="text" name="lol" id="lol" required disabled>
```

adding the disabled attribute on the input field make the datepicker not shows himself.

I've also added a new method to enable the field
```js
$('#id').datepicker('enable');
```

thnx for your attention