### PR TITLE
Prevent ENTER propagation on form

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -1200,6 +1200,8 @@
 					this.fill();
 					if (this.picker.is(':visible')){
 						e.preventDefault();
+						e.stopPropagation && e.stopPropagation();
+						e.cancelBubble = true; // IE6,7,8 support
 						if (this.o.autoclose)
 							this.hide();
 					}

--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -1200,8 +1200,11 @@
 					this.fill();
 					if (this.picker.is(':visible')){
 						e.preventDefault();
-						e.stopPropagation && e.stopPropagation();
-						e.cancelBubble = true; // IE6,7,8 support
+						if (typeof e.stopPropagation === 'function') {
+							e.stopPropagation(); // All modern browsers, IE9+
+						} else {
+							e.cancelBubble = true; // IE6,7,8 ignore "stopPropagation"
+						}
 						if (this.o.autoclose)
 							this.hide();
 					}


### PR DESCRIPTION
On "ENTER" keydown on picker, prevent the closest form to be submitted too.
Updated PR of #674