### PR TITLE
Replace ESCAPE by DOWN key to re-show picker

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -1112,7 +1112,7 @@
 
 		keydown: function(e){
 			if (this.picker.is(':not(:visible)')){
-				if (e.keyCode === 27) // allow escape to hide and re-show picker
+				if (e.keyCode === 40) // allow down to re-show picker
 					this.show();
 				return;
 			}


### PR DESCRIPTION
Replace ESCAPE by DOWN key to re-show picker.
Why?
First, ESCAPE means CANCEL or CLOSE, and it seems weird to display a picker on cnacel.
Then, to be compliant to components like SELECT, DOWN key diplays slector and ESCAPE just hides the SELECTOR
Then, there is a modal behavior issue, and specifically in a modal. Scenario : 
- open a modal
- in this modal to fill some data
- in thi modal you open a picker to select a date
- you press ESCAPE to cancel your date choice
- at this point, with the current implementation, you get an undesired behavior : the modal is closed, so you lost all data of the form instead of a closed picker only.

Updated PR of #676