### PR TITLE
Allow passing templates for heading, content and footer of Datepicker as options. 

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -1409,7 +1409,7 @@
 		todayBtn: false,
 		todayHighlight: false,
 		weekStart: 0,
-        template: {}
+		template: {},
 	};
 	var locale_opts = $.fn.datepicker.locale_opts = [
 		'format',

--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -98,7 +98,7 @@
 		if (this.component && this.component.length === 0)
 			this.component = false;
 
-		this.picker = $(DPGlobal.template);
+		this.picker = $(DPGlobal.template(this.o.template));
 		this._buildEvents();
 		this._attachEvents();
 
@@ -1408,7 +1408,8 @@
 		startView: 0,
 		todayBtn: false,
 		todayHighlight: false,
-		weekStart: 0
+		weekStart: 0,
+        template: {}
 	};
 	var locale_opts = $.fn.datepicker.locale_opts = [
 		'format',
@@ -1613,29 +1614,37 @@
 							'</tr>'+
 						'</tfoot>'
 	};
-	DPGlobal.template = '<div class="datepicker">'+
-							'<div class="datepicker-days">'+
-								'<table class=" table-condensed">'+
-									DPGlobal.headTemplate+
-									'<tbody></tbody>'+
-									DPGlobal.footTemplate+
-								'</table>'+
-							'</div>'+
-							'<div class="datepicker-months">'+
-								'<table class="table-condensed">'+
-									DPGlobal.headTemplate+
-									DPGlobal.contTemplate+
-									DPGlobal.footTemplate+
-								'</table>'+
-							'</div>'+
-							'<div class="datepicker-years">'+
-								'<table class="table-condensed">'+
-									DPGlobal.headTemplate+
-									DPGlobal.contTemplate+
-									DPGlobal.footTemplate+
-								'</table>'+
-							'</div>'+
-						'</div>';
+
+	DPGlobal.template = function(options) {
+        var headTemplate = options.headTemplate || DPGlobal.headTemplate;
+        var contTemplate = options.contTemplate || DPGlobal.contTemplate;
+        var footTemplate = options.footTemplate || DPGlobal.footTemplate;
+
+
+        return '<div class="datepicker">'+
+                  '<div class="datepicker-days">'+
+                      '<table class=" table-condensed">'+
+                          headTemplate+
+                          '<tbody></tbody>'+
+                          footTemplate+
+                      '</table>'+
+                  '</div>'+
+                  '<div class="datepicker-months">'+
+                      '<table class="table-condensed">'+
+                          headTemplate+
+                          contTemplate+
+                          footTemplate+
+                      '</table>'+
+                  '</div>'+
+                  '<div class="datepicker-years">'+
+                      '<table class="table-condensed">'+
+                          headTemplate+
+                          contTemplate+
+                          footTemplate+
+                      '</table>'+
+                  '</div>'+
+               '</div>';
+    };
 
 	$.fn.datepicker.DPGlobal = DPGlobal;
 

--- a/tests/suites/options.js
+++ b/tests/suites/options.js
@@ -646,3 +646,34 @@ test('Multidate Separator', function(){
     target.click();
     equal(input.val(), '2012-03-05 2012-03-04 2012-03-12');
 });
+
+test('Template: Custom head template', function() {
+     var input = $('<input />')
+                .appendTo('#qunit-fixture')
+                .val('2012-03-05')
+                .datepicker({
+                    format: 'yyyy-mm-dd',
+                    multidate: true,
+                    multidateSeparator: ' ',
+                    template: {
+                      headTemplate: '<thead>'+
+                                      '<tr>'+
+                                          '<th class="prev"><i class="icon-left"></i></th>'+
+                                          '<th colspan="5" class="datepicker-switch"></th>'+
+                                          '<th class="next"><i class="icon-right"></i></th>'+
+                                      '</tr>'+
+                                  '</thead>'
+                    }
+                }),
+        dp = input.data('datepicker'),
+        picker = dp.picker,
+        target;
+
+    input.focus();
+
+    target = picker.find('.prev i.icon-left')
+    equal(target.length, 3)
+
+    target = picker.find('.next i.icon-right')
+    equal(target.length, 3)
+});


### PR DESCRIPTION
Should we allow passing entire custom templates for heading, content or footer or just parts of templates like previous and next buttons?