### PR TITLE
Fix: Datepicker deletes preexisting field value

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -410,6 +410,11 @@
 		show: function(){
 			if (!this.isInline)
 				this.picker.appendTo('body');
+ 			
+ 			// prevent datepicker from wiping out field value if it 
+ 			// was set before datepicker was applied
+			this.update();
+			
 			this.picker.show();
 			this.place();
 			this._attachSecondaryEvents();


### PR DESCRIPTION
Prevents deleting of field value that was set before datepicker was applied.  Especially useful in AngularJS projects where the scope updates the DOM without notifying the datepicker object.