### PR TITLE
Update bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -4,6 +4,6 @@
   "main": ["js/bootstrap-datepicker.js", "css/datepicker.css", "css/datepicker3.css"],
   "dependencies": {
     "jquery" : ">=1.7.1",
-    "bootstrap" : ">=3.0 <4.0"
+    "bootstrap" : ">=2.0.4 <4.0"
   }
 }


### PR DESCRIPTION
Match the dependency to bootstrap that is in the docs.  Since this supports bootstrap 2 and 3 we shouldn't have a dependency requiring 3 to be used.