### PR TITLE
Add toggleActive option

### DIFF
--- a/docs/options.rst
+++ b/docs/options.rst
@@ -56,7 +56,7 @@ toggleActive
 
 Boolean. Default: true
 
-If true, selecting the currently active date in the datepicker will clear the input value.
+If true, selecting the currently active date in the datepicker will unset the respective date. This option is always true when the multidate option is being used.
 
 .. _daysofweekdisabled:
 

--- a/docs/options.rst
+++ b/docs/options.rst
@@ -51,6 +51,12 @@ If true, displays a "Clear" button at the bottom of the datepicker to clear the 
 .. figure:: _static/screenshots/option_clearbtn.png
     :align: center
 
+toggleActive
+--------
+
+Boolean. Default: true
+
+If true, selecting the currently active date in the datepicker will clear the input value.
 
 .. _daysofweekdisabled:
 

--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -1017,7 +1017,7 @@
 			if (!date){
 				this.dates.clear();
 			}
-			else if (this.o.toggleActive && ix !== -1){
+			else if (!this.o.multidate && this.o.toggleActive && ix !== -1){
 				this.dates.remove(ix);
 			}
 			else {

--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -1017,8 +1017,10 @@
 			if (!date){
 				this.dates.clear();
 			}
-			else if ((this.o.multidate > 1 || this.o.toggleActive) && ix !== -1){
-                this.dates.remove(ix);
+			else if (ix !== -1){
+                if(this.o.multidate === true || this.o.multidate > 1 || this.o.toggleActive){
+                    this.dates.remove(ix);
+                }
 			}
 			else {
 				this.dates.push(date);

--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -1018,9 +1018,9 @@
 				this.dates.clear();
 			}
 			else if (ix !== -1){
-                if(this.o.multidate === true || this.o.multidate > 1 || this.o.toggleActive){
-                    this.dates.remove(ix);
-                }
+				if(this.o.multidate === true || this.o.multidate > 1 || this.o.toggleActive){
+					this.dates.remove(ix);
+				}
 			}
 			else {
 				this.dates.push(date);
@@ -1395,7 +1395,7 @@
 		beforeShowDay: $.noop,
 		calendarWeeks: false,
 		clearBtn: false,
-        toggleActive: true,
+		toggleActive: true,
 		daysOfWeekDisabled: [],
 		endDate: Infinity,
 		forceParse: true,

--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -1017,8 +1017,8 @@
 			if (!date){
 				this.dates.clear();
 			}
-			else if (!this.o.multidate && this.o.toggleActive && ix !== -1){
-				this.dates.remove(ix);
+			else if ((this.o.multidate > 1 || this.o.toggleActive) && ix !== -1){
+                this.dates.remove(ix);
 			}
 			else {
 				this.dates.push(date);

--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -1017,7 +1017,7 @@
 			if (!date){
 				this.dates.clear();
 			}
-			else if (ix !== -1){
+			else if (this.o.toggleActive && ix !== -1){
 				this.dates.remove(ix);
 			}
 			else {
@@ -1393,6 +1393,7 @@
 		beforeShowDay: $.noop,
 		calendarWeeks: false,
 		clearBtn: false,
+        toggleActive: true,
 		daysOfWeekDisabled: [],
 		endDate: Infinity,
 		forceParse: true,

--- a/tests/suites/options.js
+++ b/tests/suites/options.js
@@ -334,6 +334,126 @@ test('Clear Button: hides datepicker if autoclose is on', function(){
 
 });
 
+test('Active Toggle Default: when active date is selected it is unset', function(){
+    var input = $('<input />')
+                .appendTo('#qunit-fixture')
+                .val('2012-03-05')
+                .datepicker({
+                    format: 'yyyy-mm-dd',
+                }),
+        dp = input.data('datepicker'),
+        picker = dp.picker,
+        target;
+
+        // open our datepicker
+        input.focus();
+
+        // Initial value is selected
+        ok(dp.dates.contains(UTCDate(2012, 2, 5)) !== -1, '2012-03-05 selected');
+
+        // click on our active date
+        target = picker.find('.datepicker-days .day.active');
+        target.click();
+
+        // make sure it's no longer set
+        equal(input.val(),'',"Input value has been cleared.");
+});
+
+test('Active Toggle Multidate Default: when one of the active dates is selected it is unset', function(){
+    var input = $('<input />')
+                .appendTo('#qunit-fixture')
+                .val('2012-03-05')
+                .datepicker({
+                    format: 'yyyy-mm-dd',
+                    multidate: true
+                }),
+        dp = input.data('datepicker'),
+        picker = dp.picker,
+        target;
+
+        // open our datepicker
+        input.focus();
+
+        // Initial value is selected
+        ok(dp.dates.contains(UTCDate(2012, 2, 5)) !== -1, '2012-03-05 in dates');
+
+        // Select additional date
+        target = picker.find('.datepicker-days tbody td:nth(7)');
+        target.click();
+        datesEqual(dp.dates.get(-1), UTCDate(2012, 2, 4), '2012-03-04 in dates');
+        datesEqual(dp.viewDate, UTCDate(2012, 2, 4));
+        equal(input.val(), '2012-03-05,2012-03-04');
+
+        // Unselect additional date
+        target = picker.find('.datepicker-days tbody td:nth(7)');
+        target.click();
+        ok(dp.dates.contains(UTCDate(2012, 2, 4)) === -1, '2012-03-04 no longer in dates');
+        datesEqual(dp.viewDate, UTCDate(2012, 2, 4));
+        equal(input.val(), '2012-03-05');
+});
+
+test('Active Toggle Disabled: when active date is selected it remains', function(){
+    var input = $('<input />')
+                .appendTo('#qunit-fixture')
+                .val('2012-03-05')
+                .datepicker({
+                    format: 'yyyy-mm-dd',
+                    toggleActive: false
+                }),
+        dp = input.data('datepicker'),
+        picker = dp.picker,
+        target;
+
+        // open our datepicker
+        input.focus();
+
+        // Initial value is selected
+        ok(dp.dates.contains(UTCDate(2012, 2, 5)) !== -1, '2012-03-05 selected');
+
+        // click on our active date
+        target = picker.find('.datepicker-days .day.active');
+        target.click();
+
+        // make sure it's still set
+        ok(dp.dates.contains(UTCDate(2012, 2, 5)) !== -1, '2012-03-05 still selected');
+        datesEqual(dp.viewDate, UTCDate(2012, 2, 5));
+        equal(input.val(), '2012-03-05');
+});
+
+test('Active Toggle Multidate Disabled: when activeToggle is set to false, but multidate is set, the option is ignored and selecting an active date it is unset', function(){
+    var input = $('<input />')
+                .appendTo('#qunit-fixture')
+                .val('2012-03-05')
+                .datepicker({
+                    format: 'yyyy-mm-dd',
+                    multidate: true,
+                    toggleActive: false
+                }),
+        dp = input.data('datepicker'),
+        picker = dp.picker,
+        target;
+
+        // open our datepicker
+        input.focus();
+
+        // Initial value is selected
+        ok(dp.dates.contains(UTCDate(2012, 2, 5)) !== -1, '2012-03-05 in dates');
+
+        // Select additional date
+        target = picker.find('.datepicker-days tbody td:nth(7)');
+        target.click();
+        datesEqual(dp.dates.get(-1), UTCDate(2012, 2, 4), '2012-03-04 in dates');
+        datesEqual(dp.viewDate, UTCDate(2012, 2, 4));
+        equal(input.val(), '2012-03-05,2012-03-04');
+
+        // Unselect additional date
+        target = picker.find('.datepicker-days tbody td:nth(7)');
+        target.click();
+        ok(dp.dates.contains(UTCDate(2012, 2, 4)) === -1, '2012-03-04 no longer in dates');
+        datesEqual(dp.viewDate, UTCDate(2012, 2, 4));
+        equal(input.val(), '2012-03-05');
+});
+
 test('DaysOfWeekDisabled', function(){
     var input = $('<input />')
                 .appendTo('#qunit-fixture')


### PR DESCRIPTION
This option prevents the date from becoming unset when clicking on the currently active date.
The current default is set to match the previous behavior.
The option is ignored when multidate is active (as there would be no easy way to unselect a date, once selected).