### PR TITLE
Option default view date

### DIFF
--- a/docs/options.rst
+++ b/docs/options.rst
@@ -65,6 +65,21 @@ Days of the week that should be disabled. Values are 0 (Sunday) to 6 (Saturday).
     :align: center
 
 
+.. _defaultviewdate:
+
+
+defaultViewDate
+---------------
+
+Object with keys ``year``, ``month``, and ``day``. Default: today
+
+Date to view when initially opening the calendar. The internal value of the date remains today as default, but when the datepicker is first opened the calendar will open to ``defaultViewDate`` rather than today. If this option is not used, "today" remains the default view date. If the given object is missing any of the required keys, their defaults are:
+
+ * ``year``: the current year
+ * ``month``: 1
+ * ``day``: 1
+
+
 .. _enddate:
 
 endDate

--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -263,9 +263,9 @@
 				o.orientation.y = _plc[0] || 'auto';
 			}
 			if (o.defaultViewDate) {
-				var year = o.defaultViewDate.year || new Date().getFullYear(),
-						month = o.defaultViewDate.month || 0,
-						day = o.defaultViewDate.day || 1;
+				var year = o.defaultViewDate.year || new Date().getFullYear();
+				var month = o.defaultViewDate.month || 0;
+				var day = o.defaultViewDate.day || 1;
 				o.defaultViewDate = UTCDate(year, month, day);
 			} else {
 				o.defaultViewDate = UTCToday();

--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -84,11 +84,11 @@
 	// Picker object
 
 	var Datepicker = function(element, options){
-		this.dates = new DateArray();
-		this.viewDate = UTCToday();
-		this.focusDate = null;
-
 		this._process_options(options);
+
+		this.dates = new DateArray();
+		this.viewDate = this.o.defaultViewDate;
+		this.focusDate = null;
 
 		this.element = $(element);
 		this.isInline = false;
@@ -261,6 +261,14 @@
 					return (/^top|bottom$/).test(word);
 				});
 				o.orientation.y = _plc[0] || 'auto';
+			}
+			if (o.defaultViewDate) {
+				var year = o.defaultViewDate.year || new Date().getFullYear(),
+						month = o.defaultViewDate.month || 0,
+						day = o.defaultViewDate.day || 1;
+				o.defaultViewDate = UTCDate(year, month, day);
+			} else {
+				o.defaultViewDate = UTCToday();
 			}
 		},
 		_events: [],

--- a/tests/suites/options.js
+++ b/tests/suites/options.js
@@ -646,3 +646,19 @@ test('Multidate Separator', function(){
     target.click();
     equal(input.val(), '2012-03-05 2012-03-04 2012-03-12');
 });
+
+test('Default View Date', function(){
+    var input = $('<input />')
+                .appendTo('#qunit-fixture')
+                .datepicker({
+                    format: 'yyyy-mm-dd',
+                    defaultViewDate: { year: 1977, month: 04, day: 25 }
+                }),
+        dp = input.data('datepicker'),
+        picker = dp.picker,
+        target;
+
+    input.focus();
+
+    equal(picker.find('.datepicker-days thead .datepicker-switch').text(), 'May 1977');
+});


### PR DESCRIPTION
When the calendar is initially opened, go to a day other than "today".