### PR TITLE
Added e.stopPropogation(); to click function to fix interaction with boo...

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -901,6 +901,7 @@
 		},
 
 		click: function(e){
+			e.stopPropagation();
 			e.preventDefault();
 			var target = $(e.target).closest('span, td, th'),
 				year, month, day;

--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -1152,7 +1152,7 @@
 						newViewDate = new Date(focusDate);
 						newViewDate.setUTCDate(focusDate.getUTCDate() + dir);
 					}
-					if (this.dateWithinRange(newDate)){
+					if (this.dateWithinRange(newViewDate)){
 						this.focusDate = this.viewDate = newViewDate;
 						this.setValue();
 						this.fill();
@@ -1180,7 +1180,7 @@
 						newViewDate = new Date(focusDate);
 						newViewDate.setUTCDate(focusDate.getUTCDate() + dir * 7);
 					}
-					if (this.dateWithinRange(newDate)){
+					if (this.dateWithinRange(newViewDate)){
 						this.focusDate = this.viewDate = newViewDate;
 						this.setValue();
 						this.fill();


### PR DESCRIPTION
...tstrap dropdowns.


Prior to this change, if a dropdown contained a bootstrap datepicker and you changed the month, it would hide the navbar.