### PR TITLE
Manage disabled input

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -408,6 +408,10 @@
 		},
 
 		show: function(){
+			var element = this.isInput? this.element : this.element.find('input');
+			if (element.attr("readonly") || element.attr("disabled")) {
+				return;
+			}
 			if (!this.isInline)
 				this.picker.appendTo('body');
 			this.picker.show();


### PR DESCRIPTION
Prevent the datepicker to be displayed for disabled or readonly input.
Note, that may cause issue for users that want both disabled input and active component.
In this case, a new boolean option should specify the behavior.