### PR TITLE
chrome bug fix

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -547,9 +547,23 @@
 				windowHeight = $window.height(),
 				scrollTop = $window.scrollTop();
 
-			var zIndex = parseInt(this.element.parents().filter(function(){
-					return $(this).css('z-index') !== 'auto';
-				}).first().css('z-index'))+10;
+            // zIndex must be greater than all the zIndex ​​of parents
+			var zIndex = 10;
+		    var parents = this.element.parents().filter(function() {
+		        return $(this).css('z-index') !== 'auto';
+		    });
+
+		    parents.each(function() {
+		        var z = parseInt($(this).css('z-index'));
+		        if (z > zIndex)
+		            zIndex = z;
+		    });
+
+			// does not work when the datepicker is located in a bootstrap-popup on chrome v:35.0.1916.153
+//			var zIndex = parseInt(this.element.parents().filter(function(){
+//					return $(this).css('z-index') !== 'auto';
+//			}).first().css('z-index')) + 10;				
+			
 			var offset = this.component ? this.component.parent().offset() : this.element.offset();
 			var height = this.component ? this.component.outerHeight(true) : this.element.outerHeight(false);
 			var width = this.component ? this.component.outerWidth(true) : this.element.outerWidth(false);


### PR DESCRIPTION
HI, I found some bug for chome version 35.0.1916.153. When markup like this:
    
    <div class="modal-dialog">
        <div class="modal-content ">
            <div class="modal-header">
			<span class="close glyphicon glyphicon-remove-circle" data-dismiss="modal"></span>
                <h4 class="modal-title">
                    Date picker
                </h4>        
            </div>
            <div class="modal-body">
                <form>
                        <div class="form-group">
                            <label>Date</label>
                            <input type="text" data-provide="datepicker" name="Date" class="form-control">
                        </div>
                </form>
            </div>
            <div class="modal-footer">
                <button data-dismiss="modal" class="btn btn-default" type="button">Cansel</button>
                <button class="btn btn-primary" type="button" id="save">Submit</button>
            </div>
        </div>
    </div>

Datepicker is shown when clicked on input  and it's zOrder=1060 in FireFox, but 10 for Chrome. So item shown under popup in Chrome. Its very easy to fix, and I do it. Unfortunately, I cant write test for this case.

![2014-06-28_205057](https://cloud.githubusercontent.com/assets/2183838/3421297/9aea63ee-fee4-11e3-86d5-11a00d4f461e.jpg)

Perhabs this will be useful fix.