### PR TITLE
The date should always be pushed

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -1020,9 +1020,8 @@
 			else if (ix !== -1){
 				this.dates.remove(ix);
 			}
-			else {
-				this.dates.push(date);
-			}
+			this.dates.push(date);
+
 			if (typeof this.o.multidate === 'number')
 				while (this.dates.length > this.o.multidate)
 					this.dates.remove(0);


### PR DESCRIPTION
I hope this doesn't break anything else, it fixes the problem where pressing enter after typing a date clears the input field.