### PR TITLE
Update bootstrap-datepicker.js

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -902,6 +902,7 @@
 
 		click: function(e){
 			e.preventDefault();
+			e.stopPropagation();
 			var target = $(e.target).closest('span, td, th'),
 				year, month, day;
 			if (target.length === 1){


### PR DESCRIPTION
The click handler conflicts if a user has a broad click handler attached to eg the body.
e.stopPropagation(); prevents the event from bubbling to any user defined click handlers.