### PR TITLE
Feature: Century Start

### DIFF
--- a/docs/options.rst
+++ b/docs/options.rst
@@ -46,7 +46,7 @@ centuryStart
 
 Number, Boolean. Default: false
 
-When using a 2 digit year format, and this option is set to a number between 1 and 99, years preceding this number will default to the 2000s, and years following it will default to the '90s.
+When using a 2 digit year format, and this option is set to a number between 1 and 99, years preceding this number will default to the 2000s, and years following it will default to the 1900s.
 
 clearBtn
 --------

--- a/docs/options.rst
+++ b/docs/options.rst
@@ -41,6 +41,13 @@ Whether or not to show week numbers to the left of week rows.
 .. figure:: _static/screenshots/option_calendarweeks.png
     :align: center
 
+centuryStart
+-------------
+
+Number, Boolean. Default: false
+
+When using a 2 digit year format, and this option is set to a number between 1 and 99, years preceding this number will default to the 2000s, and years following it will default to the '90s.
+
 clearBtn
 --------
 

--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -206,7 +206,7 @@
 					if (o.startDate instanceof Date)
 						o.startDate = this._local_to_utc(this._zero_time(o.startDate));
 					else
-						o.startDate = DPGlobal.parseDate(o.startDate, format, o.language);
+						o.startDate = DPGlobal.parseDate(o.startDate, format, o.language, o.centuryStart);
 				}
 				else {
 					o.startDate = -Infinity;
@@ -217,7 +217,7 @@
 					if (o.endDate instanceof Date)
 						o.endDate = this._local_to_utc(this._zero_time(o.endDate));
 					else
-						o.endDate = DPGlobal.parseDate(o.endDate, format, o.language);
+						o.endDate = DPGlobal.parseDate(o.endDate, format, o.language, o.centuryStart);
 				}
 				else {
 					o.endDate = Infinity;
@@ -630,7 +630,7 @@
 			}
 
 			dates = $.map(dates, $.proxy(function(date){
-				return DPGlobal.parseDate(date, this.o.format, this.o.language);
+				return DPGlobal.parseDate(date, this.o.format, this.o.language, this.o.centuryStart);
 			}, this));
 			dates = $.grep(dates, $.proxy(function(date){
 				return (
@@ -1408,7 +1408,8 @@
 		startView: 0,
 		todayBtn: false,
 		todayHighlight: false,
-		weekStart: 0
+		weekStart: 0,
+		centuryStart: false
 	};
 	var locale_opts = $.fn.datepicker.locale_opts = [
 		'format',
@@ -1463,7 +1464,7 @@
 			}
 			return {separators: separators, parts: parts};
 		},
-		parseDate: function(date, format, language){
+		parseDate: function(date, format, language, centuryStart){
 			if (!date)
 				return undefined;
 			if (date instanceof Date)
@@ -1504,7 +1505,7 @@
 						return d.setUTCFullYear(v);
 					},
 					yy: function(d,v){
-						return d.setUTCFullYear(2000+v);
+						return d.setUTCFullYear((centuryStart && v >= Math.min(Math.abs(parseInt(centuryStart, 10)), 99) ? 1900 : 2000) + v);
 					},
 					m: function(d,v){
 						if (isNaN(d))

--- a/tests/suites/options.js
+++ b/tests/suites/options.js
@@ -646,3 +646,41 @@ test('Multidate Separator', function(){
     target.click();
     equal(input.val(), '2012-03-05 2012-03-04 2012-03-12');
 });
+
+test('Century Start: 1900', function(){
+    var input = $('<input />')
+                .appendTo('#qunit-fixture')
+                .val('70-03-05')
+                .datepicker({
+                    format: 'yy-mm-dd',
+                    centuryStart: 70
+                }),
+        dp = input.data('datepicker'),
+        picker = dp.picker,
+        target;
+
+    input.focus();
+
+    target = picker.find('.datepicker-days tbody td:nth(9)');
+    target.click();
+    equal(picker.find('.datepicker-days thead .datepicker-switch').text(), 'March 1970', 'Title is "March 1970"');
+});
+
+test('Century Start: 2000', function(){
+    var input = $('<input />')
+                .appendTo('#qunit-fixture')
+                .val('69-03-05')
+                .datepicker({
+                    format: 'yy-mm-dd',
+                    centuryStart: 70
+                }),
+        dp = input.data('datepicker'),
+        picker = dp.picker,
+        target;
+
+    input.focus();
+
+    target = picker.find('.datepicker-days tbody td:nth(9)');
+    target.click();
+    equal(picker.find('.datepicker-days thead .datepicker-switch').text(), 'March 2069', 'Title is "March 2069"');
+});


### PR DESCRIPTION
When using a 2 digit year format, and this option is set to a number between 1 and 99, years preceding this number will default to the 2000s, and years following it will default to the 1900s.

So, if centuryStart is set to 70,  "70-03-05" would mean y=1970, and "69-03-05" would mean y=1969.

(The range 1970-2069 is for instance used by PHP's DateTime: http://php.net/manual/en/datetime.createfromformat.php)