### PR TITLE
Fix for #1112, assigning plugin to a local variable

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -1249,8 +1249,7 @@
 		});
 		delete options.inputs;
 
-		$(this.inputs)
-			.datepicker(options)
+		datepickerPlugin.call($(this.inputs), options)
 			.bind('changeDate', $.proxy(this.dateUpdated, this));
 
 		this.pickers = $.map(this.inputs, function(i){
@@ -1351,7 +1350,7 @@
 	}
 
 	var old = $.fn.datepicker;
-	$.fn.datepicker = function(option){
+	var datepickerPlugin = function(option){
 		var args = Array.apply(null, arguments);
 		args.shift();
 		var internal_return;
@@ -1387,6 +1386,7 @@
 		else
 			return this;
 	};
+	$.fn.datepicker = datepickerPlugin;
 
 	var defaults = $.fn.datepicker.defaults = {
 		autoclose: false,
@@ -1661,11 +1661,11 @@
 				return;
 			e.preventDefault();
 			// component click requires us to explicitly show it
-			$this.datepicker('show');
+			datepickerPlugin.call($this, 'show');
 		}
 	);
 	$(function(){
-		$('[data-provide="datepicker-inline"]').datepicker();
+		datepickerPlugin.call($('[data-provide="datepicker-inline"]'));
 	});
 
 }(window.jQuery));


### PR DESCRIPTION
Assigning the plugin to a local variable so that we can call it without invoking it as a jQuery plugin.  Before this, noConflict was not really noConflict as there was still a reliance on .datepicker()