### PR TITLE
Fixed bug. Keybord left and up do not work after clicking right/down. In...

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -1151,7 +1151,7 @@
 						newViewDate = new Date(focusDate);
 						newViewDate.setUTCDate(focusDate.getUTCDate() + dir);
 					}
-					if (this.dateWithinRange(newDate)){
+					if (this.dateWithinRange(newViewDate)){
 						this.focusDate = this.viewDate = newViewDate;
 						this.setValue();
 						this.fill();
@@ -1179,7 +1179,7 @@
 						newViewDate = new Date(focusDate);
 						newViewDate.setUTCDate(focusDate.getUTCDate() + dir * 7);
 					}
-					if (this.dateWithinRange(newDate)){
+					if (this.dateWithinRange(newViewDate)){
 						this.focusDate = this.viewDate = newViewDate;
 						this.setValue();
 						this.fill();


### PR DESCRIPTION
Keybord left and up do not work after clicking right/down. In case when startDate = +1 and date was not set. I think that method dateWithinRange get wrong arument. newDate which is allways default date +-1. It should be newViewate, because arrows navigate on view.
I found bug on IE11. And after fix test on lates version of Firefoz and Chrome.

Best regards
Adam Pryka
wishmaster80