### PR TITLE
Corrected month and year display issue in Bootstrap 3

### DIFF
--- a/less/datepicker3.less
+++ b/less/datepicker3.less
@@ -72,7 +72,7 @@
 	&.years div.datepicker-years {
 		display: block;
 	}
-	table{
+	table {
 		margin: 0;
 		-webkit-touch-callout: none;
 		-webkit-user-select: none;
@@ -80,13 +80,13 @@
 		-moz-user-select: none;
 		-ms-user-select: none;
 		user-select: none;
+		width: 100%;
 		tr {
 			td, th {
 				text-align: center;
 				width: 30px;
 				height: 30px;
 				border-radius: 4px;
-
 				border: none;
 			}
 		}
@@ -195,7 +195,7 @@
 	thead tr:first-child th,
 	tfoot tr th {
 		cursor: pointer;
-		&:hover{
+		&:hover {
 			background: @gray-lighter;
 		}
 	}


### PR DESCRIPTION
This pull request fixes a display issue with the month and year views when using Bootstrap 3. The following screenshots illustrate the issue: 
![screen shot 2014-12-30 at 8 53 39 am](https://cloud.githubusercontent.com/assets/1034813/5580804/117812a2-9005-11e4-9c11-82786aa496e9.png)
![screen shot 2014-12-30 at 8 53 33 am](https://cloud.githubusercontent.com/assets/1034813/5580805/13d88d74-9005-11e4-83c7-1f2a9b933eb2.png)

Here are the same screenshots after the fix:
![screen shot 2014-12-30 at 9 20 51 am](https://cloud.githubusercontent.com/assets/1034813/5580814/3fe2062a-9005-11e4-8188-209cd15a5386.png)
![screen shot 2014-12-30 at 9 21 05 am](https://cloud.githubusercontent.com/assets/1034813/5580816/41706c5c-9005-11e4-842d-c7970f4d415d.png)

Some other very minor changes for consistency were also committed, such as removing a couple extra line breaks and adding a couple of spaces before brackets. 