### PR TITLE
Update bower.json dependencies

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,8 +3,7 @@
   "version": "1.4.0",
   "main": ["js/bootstrap-datepicker.js", "css/datepicker.css", "css/datepicker3.css"],
   "dependencies": {
-    "jquery" : ">=1.7.1",
-    "bootstrap" : ">=2.0.4 <4.0"
+    "jquery" : ">=1.7.1"
   },
   "ignore": {}
 }


### PR DESCRIPTION
The official bootstrap package can be avoided for those who are using the official bootstrap-sass source. No need to download the LESS version.