### PR TITLE
Update bootstrap-datepicker.js

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -593,7 +593,7 @@
 				appendOffset = $(this.o.container).offset();
 			// get zIndex from CSS or parent stack - allows explicit set in stylesheet
 			this.picker.css('z-index','');	// reset zIndex
-			var zIndex = (this.picker.css('z-index') != 'auto' ? this.picker.css('z-index') : (function(element) {
+			var zIndex = (this.picker.css('z-index') !== 'auto' ? this.picker.css('z-index') : (function(element) {
 				var parentsZindex = [];
 				element.parents().each(function() {
 					var itemZIndex = $(this).css('z-index');

--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -591,13 +591,16 @@
 				windowHeight = $(this.o.container).height(),
 				scrollTop = $(this.o.container).scrollTop(),
 				appendOffset = $(this.o.container).offset();
-
-			var parentsZindex = [];
-			this.element.parents().each(function() {
-				var itemZIndex = $(this).css('z-index');
-				if ( itemZIndex !== 'auto' && itemZIndex !== 0 ) parentsZindex.push( parseInt( itemZIndex ) );
-			});
-			var zIndex = Math.max.apply( Math, parentsZindex ) + 10;
+			// get zIndex from CSS or parent stack - allows explicit set in stylesheet
+			this.picker.css('z-index','');	// reset zIndex
+			var zIndex = (this.picker.css('z-index') != 'auto' ? this.picker.css('z-index') : (function(element) {
+				var parentsZindex = [];
+				element.parents().each(function() {
+					var itemZIndex = $(this).css('z-index');
+					if ( itemZIndex !== 'auto' && itemZIndex !== 0 ) parentsZindex.push( parseInt( itemZIndex ) );
+				});
+				return Math.max.apply( Math, parentsZindex ) + 10;
+			})(this.element));
 			var offset = this.component ? this.component.parent().offset() : this.element.offset();
 			var height = this.component ? this.component.outerHeight(true) : this.element.outerHeight(false);
 			var width = this.component ? this.component.outerWidth(true) : this.element.outerWidth(false);


### PR DESCRIPTION
Updated z-index functionality in "place" function to check for explicit z-index set through stylesheet. Current func. retrieves z-index based on DOM stack. In some instances you might want to specify the z-index through a CSS class instead. Updated func. will first reset picker z-index and check for z-index set via stylesheet. If not-specified, DOM stack is used.