### PR TITLE
Added option to not show datepicker on readonly field

### DIFF
--- a/docs/options.rst
+++ b/docs/options.rst
@@ -290,3 +290,10 @@ disableTouchKeyboard
 Boolean.  Default: false
 
 If true, no keyboard will show on mobile devices
+
+enableOnReadonly
+----------------
+
+Boolean. Default: true
+
+If false the datepicker will not show on a readonly datepicker field.

--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -429,7 +429,7 @@
 		},
 
 		show: function(){
-			if (this.element.attr('readonly'))
+			if (this.element.attr('readonly') && this.o.enableOnReadonly === false)
 				return;
 			if (!this.isInline)
 				this.picker.appendTo(this.o.container);
@@ -1531,6 +1531,7 @@
 		todayHighlight: false,
 		weekStart: 0,
 		disableTouchKeyboard: false,
+        enableOnReadonly: true,
 		container: 'body'
 	};
 	var locale_opts = $.fn.datepicker.locale_opts = [

--- a/tests/suites/options.js
+++ b/tests/suites/options.js
@@ -904,3 +904,32 @@ test('Default View Date', function(){
 
     equal(picker.find('.datepicker-days thead .datepicker-switch').text(), 'May 1977');
 });
+
+//datepicker-dropdown
+
+test('Enable on readonly options (default)', function(){
+    var input = $('<input readonly="readonly" />')
+            .appendTo('#qunit-fixture')
+            .datepicker({format: "dd-mm-yyyy"}),
+        dp = input.data('datepicker'),
+        picker = dp.picker;
+
+    ok(!picker.is(':visible'));
+    input.focus();
+    ok(picker.is(':visible'));
+});
+
+test('Enable on readonly options (false)', function(){
+    var input = $('<input readonly="readonly" />')
+            .appendTo('#qunit-fixture')
+            .datepicker({
+                format: "dd-mm-yyyy",
+                enableOnReadonly: false
+            }),
+        dp = input.data('datepicker'),
+        picker = dp.picker;
+
+    ok(!picker.is(':visible'));
+    input.focus();
+    ok(!picker.is(':visible'));
+});


### PR DESCRIPTION
This option fixes #1231. The default behavior is restored and displaying of the datepicker can be disabled for readonly inputs if a users wants it that way.

Not sure if the option name is a good name