### PR TITLE
Bug #820 correction

### DIFF
--- a/docs/options.rst
+++ b/docs/options.rst
@@ -276,3 +276,17 @@ Day of the week start. 0 (Sunday) to 6 (Saturday)
 
 .. figure:: _static/screenshots/option_weekstart.png
     :align: center
+
+showOnFocus
+-----------
+
+Boolean.  Default: true
+
+If false, the datepicker will be prevented from showing when the input field associated with it receives focus.
+
+disableTouchKeyboard
+--------------------
+
+Boolean.  Default: false
+
+If true, no keyboard will show on mobile devices

--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -376,7 +376,7 @@
 					resize: $.proxy(this.place, this)
 				}],
 				[$(document), {
-					'mousedown touchstart': $.proxy(function(e){
+					mousedown: $.proxy(function(e){
 						// Clicked outside the datepicker, hide it
 						if (!(
 							this.element.is(e.target) ||


### PR DESCRIPTION
On mobile, when scrolling, the popup was closed.
Simply don't use touchstart/touchend : mousedown will be trigger on touchend IF there is no scroll.
When there is a scroll event between touchstart and touchend, mouse isn't triggered.