### PR TITLE
Include "main" property in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "datepicker",
     "twitter-bootstrap"
   ],
+  "main": "./dist/js/bootstrap-datepicker.js",
   "homepage": "https://github.com/eternicode/bootstrap-datepicker",
   "author": "Andrew Rowls <eternicode@gmail.com>",
   "scripts": {


### PR DESCRIPTION
This will enable the datepicker to be included via `require('bootstrap-datepicker')` when using browserify/webpack.