### PR TITLE
Use $.on() instead $.bind().

### DIFF
--- a/docs/options.rst
+++ b/docs/options.rst
@@ -80,9 +80,9 @@ Appends the date picker popup to a specific element; eg: container: '#picker-con
 daysOfWeekDisabled
 ------------------
 
-String, Array.  Default: '', []
+String, Array.  Default: []
 
-Days of the week that should be disabled. Values are 0 (Sunday) to 6 (Saturday). Multiple values should be comma-separated. Example: disable weekends: ``'0,6'`` or ``[0,6]``.
+Days of the week that should be disabled. Values are 0 (Sunday) to 6 (Saturday). Multiple values should be comma-separated. Example: disable weekends: ``06`` or ``'0,6'`` or ``[0,6]``.
 
 .. figure:: _static/screenshots/option_daysofweekdisabled.png
     :align: center

--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -1366,7 +1366,7 @@
 		delete options.inputs;
 
 		datepickerPlugin.call($(this.inputs), options)
-			.bind('changeDate', $.proxy(this.dateUpdated, this));
+			.on('changeDate', $.proxy(this.dateUpdated, this));
 
 		this.pickers = $.map(this.inputs, function(i){
 			return $(i).data('datepicker');
@@ -1531,7 +1531,7 @@
 		todayHighlight: false,
 		weekStart: 0,
 		disableTouchKeyboard: false,
-        enableOnReadonly: true,
+		enableOnReadonly: true,
 		container: 'body'
 	};
 	var locale_opts = $.fn.datepicker.locale_opts = [


### PR DESCRIPTION
"As of jQuery 1.7, the .on() method is the preferred method for attaching event handlers to a document." (http://api.jquery.com/bind/)