### PR TITLE
Enables right-click and edit-menu paste for the datepicker

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -322,7 +322,8 @@
                     if ($.inArray(e.keyCode, [27, 37, 39, 38, 40, 32, 13, 9]) === -1)
                         this.update();
                 }, this),
-                keydown: $.proxy(this.keydown, this)
+                keydown: $.proxy(this.keydown, this),
+                paste: $.proxy(this.paste, this)
             };
 
             if (this.o.showOnFocus === true) {
@@ -476,6 +477,23 @@
 				delete this.element.data().date;
 			}
 			return this;
+		},
+
+		paste: function(evt){
+			var dateString;
+			if (evt.originalEvent.clipboardData && evt.originalEvent.clipboardData.types
+				&& $.inArray('text/plain', evt.originalEvent.clipboardData.types) !== -1) {
+				dateString = evt.originalEvent.clipboardData.getData('text/plain');
+			}
+			else if (window.clipboardData) {
+				dateString = window.clipboardData.getData('Text');
+			}
+			else {
+				return;
+			}
+			this.setDate(dateString);
+			this.update();
+			evt.preventDefault();
 		},
 
 		_utc_to_local: function(utc){

--- a/tests/suites/events.js
+++ b/tests/suites/events.js
@@ -304,3 +304,18 @@ test('setDate: triggers change and changeDate events', function(){
     equal(triggered_change, 2);
     equal(triggered_changeDate, 1);
 });
+
+test('paste must update the date', function() {
+    var dateToPaste = '22-07-2015';
+    var evt = {
+        type: 'paste',
+        originalEvent: {
+            clipboardData: {
+                types: ['text/plain'],
+                getData: function() { return dateToPaste; }
+            }
+        }
+    };
+    this.input.trigger(evt);
+    datesEqual(this.dp.dates[0], UTCDate(2015, 6, 22));
+});


### PR DESCRIPTION
Addresses #778 

Note: the test I added currently fails. The reason is that the expected UTC date is off:

>> Events - paste must update the date
>> Message: null
>> Actual: "2015-07-22 00:00:00.00"
>> Expected: "2015-08-22 00:00:00.00"
>> at datesEqual (file:///Users/rhogg/src/datePicker/tests/assets/utils.js:20)

Two existing tests fail on master (without any of my changes) for the same reason, so I'm not sure what to do. Either I could a) doctor the test so it passes and add a FIXME or b) leave it as is or c) fix the test because I'm doing something wrong, it's up to you.