### PR TITLE
Replace ESCAPE by DOWN key to re-show picker (test)

### DIFF
--- a/tests/suites/keyboard_navigation/2012.js
+++ b/tests/suites/keyboard_navigation/2012.js
@@ -459,7 +459,7 @@ test('Toggle hide/show (escape); navigation while hidden is suppressed', functio
     // Show
     this.input.trigger({
         type: 'keydown',
-        keyCode: 27
+        keyCode: 40
     });
 
     ok(this.picker.is(':visible'), 'Picker is visible');


### PR DESCRIPTION
Test update for  #1300.
Changes :
Escape when hidden --> does not show the picker anymore
Down when hidden --> show the picker