### PR TITLE
Feature : Days of week highlighted

### DIFF
--- a/docs/options.rst
+++ b/docs/options.rst
@@ -87,6 +87,15 @@ Days of the week that should be disabled. Values are 0 (Sunday) to 6 (Saturday).
 .. figure:: _static/screenshots/option_daysofweekdisabled.png
     :align: center
 
+.. _daysofweekhighlighted:
+
+daysOfWeekHighlighted
+---------------------
+
+String, Array.  Default: []
+
+Days of the week that should be highlighted. Values are 0 (Sunday) to 6 (Saturday). Multiple values should be comma-separated. Example: highlight weekends: ``06`` or ``'0,6'`` or ``[0,6]``.
+
 .. _datesdisabled:
 
 datesDisabled

--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -131,6 +131,7 @@
 		this.setStartDate(this._o.startDate);
 		this.setEndDate(this._o.endDate);
 		this.setDaysOfWeekDisabled(this.o.daysOfWeekDisabled);
+		this.setDaysOfWeekHighlighted(this.o.daysOfWeekHighlighted);
 		this.setDatesDisabled(this.o.datesDisabled);
 
 		this.fillDow();
@@ -232,6 +233,13 @@
 			if (!$.isArray(o.daysOfWeekDisabled))
 				o.daysOfWeekDisabled = o.daysOfWeekDisabled.split(/[,\s]*/);
 			o.daysOfWeekDisabled = $.map(o.daysOfWeekDisabled, function(d){
+				return parseInt(d, 10);
+			});
+          
+  			o.daysOfWeekHighlighted = o.daysOfWeekHighlighted||[];
+			if (!$.isArray(o.daysOfWeekHighlighted))
+				o.daysOfWeekHighlighted = o.daysOfWeekHighlighted.split(/[,\s]*/);
+			o.daysOfWeekHighlighted = $.map(o.daysOfWeekHighlighted, function(d){
 				return parseInt(d, 10);
 			});
 
@@ -613,6 +621,12 @@
 			this.updateNavArrows();
 			return this;
 		},
+        
+		setDaysOfWeekHighlighted: function(daysOfWeekHighlighted){
+			this._process_options({daysOfWeekHighlighted: daysOfWeekHighlighted});
+			this.update();
+			return this;
+		},
 
 		setDatesDisabled: function(datesDisabled){
 			this._process_options({datesDisabled: datesDisabled});
@@ -829,6 +843,10 @@
 			if (date.valueOf() < this.o.startDate || date.valueOf() > this.o.endDate ||
 				$.inArray(date.getUTCDay(), this.o.daysOfWeekDisabled) !== -1){
 				cls.push('disabled');
+			}
+			if (date.valueOf() < this.o.startDate || date.valueOf() > this.o.endDate ||
+				$.inArray(date.getUTCDay(), this.o.daysOfWeekHighlighted) !== -1){
+				cls.push('highlighted');
 			}
 			if (this.o.datesDisabled.length > 0 &&
 				$.grep(this.o.datesDisabled, function(d){
@@ -1532,6 +1550,7 @@
 		clearBtn: false,
 		toggleActive: false,
 		daysOfWeekDisabled: [],
+		daysOfWeekHighlighted: [],
 		datesDisabled: [],
 		endDate: Infinity,
 		forceParse: true,

--- a/less/datepicker3.less
+++ b/less/datepicker3.less
@@ -99,9 +99,9 @@
 			color: @btn-link-disabled-color;
 			cursor: default;
 		}
-        &.highlighted{
+		&.highlighted{
 			background: @state-info-bg;
-            border-radius: 0;
+			border-radius: 0;
 		}
 		&.today,
 		&.today:hover,

--- a/less/datepicker3.less
+++ b/less/datepicker3.less
@@ -99,6 +99,10 @@
 			color: @btn-link-disabled-color;
 			cursor: default;
 		}
+        &.highlighted{
+			background: @state-info-bg;
+            border-radius: 0;
+		}
 		&.today,
 		&.today:hover,
 		&.today.disabled,

--- a/tests/suites/options.js
+++ b/tests/suites/options.js
@@ -502,6 +502,28 @@ test('DaysOfWeekDisabled', function(){
     ok(target.hasClass('disabled'), 'Day of week is disabled');
 });
 
+test('DaysOfWeekHighlighted', function(){
+    var input = $('<input />')
+                .appendTo('#qunit-fixture')
+                .val('2012-10-26')
+                .datepicker({
+                    format: 'yyyy-mm-dd',
+                    daysOfWeekHighlighted: '1,5'
+                }),
+        dp = input.data('datepicker'),
+        picker = dp.picker,
+        target;
+
+
+    input.focus();
+    target = picker.find('.datepicker-days tbody td:nth(22)');
+    ok(target.hasClass('highlighted'), 'Day of week is highlighted');
+    target = picker.find('.datepicker-days tbody td:nth(24)');
+    ok(!target.hasClass('highlighted'), 'Day of week is highlighted');
+    target = picker.find('.datepicker-days tbody td:nth(26)');
+    ok(target.hasClass('highlighted'), 'Day of week is highlighted');
+});
+
 
 test('DatesDisabled', function(){
     var input = $('<input />')


### PR DESCRIPTION
I was looking for a feature that can do a bit more than daysOfWeekDisabled : Highlight some day(s) highlighting without disabling them. 
This is usefull for highlighting weekend for example.
The code is almost the same as the daysOfWeekDisabled feature, without the disabling part.

![dayshighlighted](https://cloud.githubusercontent.com/assets/1029845/6693446/4bb398dc-ccd3-11e4-9081-5f8fdcb9272c.png)
