### PR TITLE
Add immediateUpdates option (updates input when a year or month is selected)

### DIFF
--- a/docs/options.rst
+++ b/docs/options.rst
@@ -297,3 +297,10 @@ enableOnReadonly
 Boolean. Default: true
 
 If false the datepicker will not show on a readonly datepicker field.
+
+immediateUpdates
+---------------------
+
+Boolean. Default: false
+
+If true, selecting a year or month in the datepicker will update the input value immediately. Otherwise, only selecting a day of the month will update the input value immediately.

--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -369,6 +369,15 @@
 				}]
 			);
 
+			if (this.o.immediateUpdates) {
+				// Trigger input updates immediately on changed year/month
+				this._events.push([this.element, {
+					'changeYear changeMonth': $.proxy(function(e){
+						this.update(e.date);
+					}, this)
+				}]);
+			}
+
 			this._secondaryEvents = [
 				[this.picker, {
 					click: $.proxy(this.click, this)
@@ -1550,7 +1559,8 @@
 		weekStart: 0,
 		disableTouchKeyboard: false,
 		enableOnReadonly: true,
-		container: 'body'
+		container: 'body',
+		immediateUpdates: false
 	};
 	var locale_opts = $.fn.datepicker.locale_opts = [
 		'format',

--- a/tests/suites/options.js
+++ b/tests/suites/options.js
@@ -905,6 +905,33 @@ test('Default View Date', function(){
     equal(picker.find('.datepicker-days thead .datepicker-switch').text(), 'May 1977');
 });
 
+test('Immediate Updates', function(){
+    var input = $('<input />')
+                .appendTo('#qunit-fixture')
+                .val('2014-01-01')
+                .datepicker({
+                    format: 'yyyy-mm-dd',
+                    immediateUpdates: true
+                }),
+        dp = input.data('datepicker'),
+        picker = dp.picker;
+
+    // Change month
+    input.focus();
+    picker.find('.datepicker-days .next').click();
+    equal(input.val(), '2014-02-01');
+
+    // Change year
+    picker.find('.datepicker-days .datepicker-switch').click();
+    picker.find('.datepicker-months .next').click();
+    equal(input.val(), '2015-02-01');
+
+    // Change year set (doesn't update input)
+    picker.find('.datepicker-months .datepicker-switch').click();
+    picker.find('.datepicker-years .next').click();
+    equal(input.val(), '2015-02-01');
+});
+
 //datepicker-dropdown
 
 test('Enable on readonly options (default)', function(){


### PR DESCRIPTION
Fixes #1323.

> immediateUpdates
> ---------------------
> 
> Boolean. Default: false
> 
> If true, selecting a year or month in the datepicker will update the input value immediately. Otherwise, only selecting a day of the month will update the input value immediately.