### PR TITLE
Fixes the issue with a date change firing mulitple change events

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -773,6 +773,7 @@
 				this._trigger('clearDate');
 
 			this.fill();
+			this.element.change();
 			return this;
 		},
 

--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -583,11 +583,11 @@
 			var formatted = this.getFormattedDate();
 			if (!this.isInput){
 				if (this.component){
-					this.element.find('input').val(formatted).change();
+					this.element.find('input').val(formatted);
 				}
 			}
 			else {
-				this.element.val(formatted).change();
+				this.element.val(formatted);
 			}
 			return this;
 		},

--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -550,7 +550,7 @@
 			}
 
 			if (element) {
-				element.val('').change();
+				element.val('');
 			}
 
 			this.update();

--- a/tests/suites/events.js
+++ b/tests/suites/events.js
@@ -301,7 +301,7 @@ test('setDate: triggers change and changeDate events', function(){
 
     this.dp.setDate(new Date(2011, 2, 5));
 
-    equal(triggered_change, 0);
+    equal(triggered_change, 1);
     equal(triggered_changeDate, 1);
 });
 

--- a/tests/suites/events.js
+++ b/tests/suites/events.js
@@ -301,7 +301,7 @@ test('setDate: triggers change and changeDate events', function(){
 
     this.dp.setDate(new Date(2011, 2, 5));
 
-    equal(triggered_change, 2);
+    equal(triggered_change, 0);
     equal(triggered_changeDate, 1);
 });
 


### PR DESCRIPTION
This PR fixes the issue with a date change firing multiple change events as reported in #1233 

Fix is pulled from [this issue](https://github.com/vizjerai/bootstrap-datepicker/issues/4) and [this commit](https://github.com/vizjerai/bootstrap-datepicker/commit/db20cae1d6ada09c9693fb780567388508b3ff57)

I've tested this locally and all seems to be working OK with it.