### PR TITLE
Better Polish language date shortcuts translation and default date format

### DIFF
--- a/js/locales/bootstrap-datepicker.pl.js
+++ b/js/locales/bootstrap-datepicker.pl.js
@@ -4,13 +4,14 @@
  */
 ;(function($){
     $.fn.datepicker.dates['pl'] = {
-        days: ["Niedziela", "Poniedziałek", "Wtorek", "Środa", "Czwartek", "Piątek", "Sobota"],
-        daysShort: ["Nie", "Pn", "Wt", "Śr", "Czw", "Pt", "So"],
-        daysMin: ["N", "Pn", "Wt", "Śr", "Cz", "Pt", "So"],
-        months: ["Styczeń", "Luty", "Marzec", "Kwiecień", "Maj", "Czerwiec", "Lipiec", "Sierpień", "Wrzesień", "Październik", "Listopad", "Grudzień"],
-        monthsShort: ["Sty", "Lu", "Mar", "Kw", "Maj", "Cze", "Lip", "Sie", "Wrz", "Pa", "Lis", "Gru"],
-        today: "Dzisiaj",
+        days: ["niedziela", "poniedziałek", "wtorek", "środa", "czwartek", "piątek", "sobota"],
+        daysShort: ["niedz.", "pon.", "wt.", "śr.", "czw.", "piąt.", "sob."],
+        daysMin: ["ndz.", "pn.", "wt.", "śr.", "czw.", "pt.", "sob."],
+        months: ["styczeń", "luty", "marzec", "kwiecień", "maj", "czerwiec", "lipiec", "sierpień", "wrzesień", "październik", "listopad", "grudzień"],
+        monthsShort: ["sty.", "lut.", "mar.", "kwi.", "maj", "cze.", "lip.", "sie.", "wrz.", "paź.", "lis.", "gru."],
+        today: "dzisiaj",
         weekStart: 1,
-        clear: "Wyczyść"
+        clear: "wyczyść",
+        format: "dd.mm.yyyy"
     };
 }(jQuery));


### PR DESCRIPTION
I would like to propose better from Polish grammatical point of view language translation for weekdays, months and their shortcuts.

Added default date format.