### PR TITLE
Trigger "hide" event on click outside

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -394,7 +394,7 @@
 							this.picker.is(e.target) ||
 							this.picker.find(e.target).length
 						)){
-							$(this.picker).hide();
+							this.hide();
 						}
 					}, this)
 				}]


### PR DESCRIPTION
`hide` event is being triggered correctly when popup is dismissed with escape key, by tabbing to next field or clicking date or clear button. This change makes it trigger also popup is dismissed by clicking outside.