### PR TITLE
appendOffset.top removed

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -684,7 +684,7 @@
 			var height = this.component ? this.component.outerHeight(true) : this.element.outerHeight(false);
 			var width = this.component ? this.component.outerWidth(true) : this.element.outerWidth(false);
 			var left = offset.left - appendOffset.left,
-				top = offset.top - appendOffset.top;
+				top = offset.top;
 
 			this.picker.removeClass(
 				'datepicker-orient-top datepicker-orient-bottom '+


### PR DESCRIPTION
Tested on my bootstrap 3 and on http://eternicode.github.io/bootstrap-datepicker/ 

Fixed my issue https://github.com/eternicode/bootstrap-datepicker/issues/1364#issuecomment-93418946

I think bootstrap 3 has changed and doesn't need this old fix anymore.
I can't find what is this ```appendOffset``` needed for so I only removed the subtraction of ```appendOffset.top``` as I were only having top position alignment problems.