### PR TITLE
Small performance fix

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -820,8 +820,7 @@
 					.attr('colspan', function(i, val){
 						return parseInt(val) + 1;
 					});
-				var cell = '<th class="cw">&#160;</th>';
-				html += cell;
+				html += '<th class="cw">&#160;</th>';
 			}
 			while (dowCnt < this.o.weekStart + 7){
 				html += '<th class="dow">'+dates[this.o.language].daysMin[(dowCnt++)%7]+'</th>';

--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -669,10 +669,11 @@
 			var calendarWidth = this.picker.outerWidth(),
 				calendarHeight = this.picker.outerHeight(),
 				visualPadding = 10,
-				windowWidth = $(this.o.container).width(),
-				windowHeight = $(this.o.container).height(),
-				scrollTop = $(this.o.container).scrollTop(),
-				appendOffset = $(this.o.container).offset();
+				container = $(this.o.container),
+				windowWidth = container.width(),
+				windowHeight = container.height(),
+				scrollTop = container.scrollTop(),
+				appendOffset = container.offset();
 
 			var parentsZindex = [];
 			this.element.parents().each(function(){


### PR DESCRIPTION
Hello!
This PR is fix for #1227, now we cache fatty jQuery object, and this works from 20% to 90% faster.
(20 for [selection by id](http://jsperf.com/caching-jquery-objects-perf/18)) (90 for [selection by class](http://jsperf.com/caching-jquery-objects-perf/13))
