### PR TITLE
Update of datepicker-bootstrap.js, better print out of the days

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -909,7 +909,7 @@
 			if (isNaN(year) || isNaN(month))
 				return;
 			this.picker.find('.datepicker-days thead .datepicker-switch')
-            .text(dates[this.o.language].months[month]+' '+ (this.o.maxViewMode < 2 ? '' : year));
+            .text(dates[this.o.language].months[month]+' '+ (this.o.maxViewMode >= 2 || this.o.showYearInDaysView ? year : ''));
       this.picker.find('tfoot .today')
 						.text(todaytxt)
 						.toggle(this.o.todayBtn !== false);
@@ -922,8 +922,26 @@
 				day = DPGlobal.getDaysInMonth(prevMonth.getUTCFullYear(), prevMonth.getUTCMonth());
 			prevMonth.setUTCDate(day);
 			prevMonth.setUTCDate(day - (prevMonth.getUTCDay() - this.o.weekStart + 7)%7);
-			var nextMonth = new Date(prevMonth);
-			nextMonth.setUTCDate(nextMonth.getUTCDate() + 42);
+			var currMonth = new Date();
+		        currMonth.setUTCMonth(prevMonth.getUTCMonth() + 1);
+		
+	            	var offsetDate = new Date(year, currMonth.getUTCMonth());
+	            	var nextMonth = new Date(prevMonth);
+	
+	            	var offset = daysInWeek * 6;
+	
+	            	if ( offsetDate.getUTCDay() > 0 && offsetDate.getUTCDay() < 5 ) {
+	                	offset = daysInWeek * 5;
+	            	}
+	
+	            	if ( offsetDate.getUTCDay() === 0 ) {
+	                	if ( offsetDate.getUTCMonth() === 1 && DPGlobal.getDaysInMonth(offsetDate.getUTCFullYear(), offsetDate.getUTCMonth()) === 28 ) {
+	                    		offset = daysInWeek * 4;
+	                	}
+	                	prevMonth.setUTCDate( prevMonth.getUTCDate() + 7 );
+	            	}
+	            	
+			nextMonth.setUTCDate(nextMonth.getUTCDate() + offset);
 			nextMonth = nextMonth.valueOf();
 			var html = [];
 			var clsName;
@@ -1605,7 +1623,8 @@
 		disableTouchKeyboard: false,
 		enableOnReadonly: true,
 		container: 'body',
-		immediateUpdates: false
+		immediateUpdates: false,
+        	showYearInDaysView: false
 	};
 	var locale_opts = $.fn.datepicker.locale_opts = [
 		'format',


### PR DESCRIPTION
Added better logic for printing out days of the current month. For example if the UTC day of week was 0 you would get whole first row of previous month, instead first row should already begin with the new month. Another fix is printing out additional last row of next month when, days of week were 1,2,3,4. Third fix is new options for datepicker where we can explicitly set to show the current year in the datepicker-switch td element.

TODO: another great fix would be to remove characters from <th class="prev">&#171;</th> and <th class="next">&#187;</th> so we can style it with the classes