### PR TITLE
Add .gitignore to gh-pages branch to ease branch switching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules


### PR DESCRIPTION
Adding .gitignore to gh-pages branch will make switching back and forth between branches less annoying.

I've just added node_modules to the list for now.