### PR TITLE
"Twitter Bootstrap" => "Bootstrap"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "eternicode/bootstrap-datepicker",
-    "description": "A datepicker for twitter bootstrap forked from Stefan Petre's (of eyecon.ro)",
+    "description": "A datepicker for Bootstrap forked from Stefan Petre's (of eyecon.ro)",
     "license": "Apache-2.0",
     "keywords": [
         "bootstrap",

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,7 +1,7 @@
 bootstrap-datepicker
 ====================
 
-Bootstrap-datepicker provides a flexible datepicker widget in the Twitter bootstrap style.
+Bootstrap-datepicker provides a flexible datepicker widget in the Bootstrap style.
 
 .. figure:: _static/screenshots/demo_head.png
     :align: center
@@ -21,7 +21,7 @@ Requirements
 * `Bootstrap`_ 2.0.4+
 * `jQuery`_ 1.7.1+
 
-.. _Bootstrap: http://twitter.github.com/bootstrap/
+.. _Bootstrap: http://getbootstrap.com/
 .. _jQuery: http://jquery.com/
 
 These are the specific versions bootstrap-datepicker is tested against (``js`` files) and built against (``css`` files).  Use other versions at your own risk.

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "bootstrap-datepicker",
-  "description": "A datepicker for twitter bootstrap forked from Stefan Petre's (of eyecon.ro), improvements by eternicode",
+  "description": "A datepicker for Bootstrap forked from Stefan Petre's (of eyecon.ro), improvements by eternicode",
   "version": "1.5.0-dev",
   "license": "Apache-2.0",
   "keywords": [
     "datepicker",
-    "twitter-bootstrap"
+    "bootstrap"
   ],
   "main": "./dist/js/bootstrap-datepicker.js",
   "homepage": "https://github.com/eternicode/bootstrap-datepicker",


### PR DESCRIPTION
Also updates the homepage URL for Bootstrap.

Since version 3, Bootstrap is no longer organizationally affiliated with Twitter.
See http://getbootstrap.com/about/#name and https://github.com/twbs/bootstrap/issues/9899