### PR TITLE
Do not hide inline picker

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -420,7 +420,8 @@
 							this.element.is(e.target) ||
 							this.element.find(e.target).length ||
 							this.picker.is(e.target) ||
-							this.picker.find(e.target).length
+							this.picker.find(e.target).length ||
+							this.picker.hasClass('datepicker-inline')
 						)){
 							$(this.picker).hide();
 						}


### PR DESCRIPTION
When in a custom setup (I have two inline pickers in a bootstrap collapse div), the  click event from the collapse trigger will set `style="display:none"` on the two inline pickers. Testing for the `.datepicker-inline` class on the picker will inhibit this (unwanted) behaviour.