### PR TITLE
point the bower package at the dist/*.js rather than js/*.js

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -4,7 +4,7 @@
   "main": [
     "dist/css/bootstrap-datepicker.css",
     "dist/css/bootstrap-datepicker3.css",
-    "js/bootstrap-datepicker.js"
+    "dist/js/bootstrap-datepicker.min.js"
   ],
   "license": "Apache-2.0",
   "dependencies": {


### PR DESCRIPTION
The bower package is pointing at the pre-build bootstrap-datepicker.js.  This changes it to point at the dist version.