### PR TITLE
Link to last stable release docs instead of dev docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Versions are incremented according to [semver](http://semver.org/).
 ## Links
 
 * [Online Demo](http://eternicode.github.io/bootstrap-datepicker/)
-* [Online Docs](http://bootstrap-datepicker.readthedocs.org/) (ReadTheDocs.com)
+* [Online Docs](http://bootstrap-datepicker.readthedocs.org/en/stable/) (ReadTheDocs.com)
 * [Google Group](https://groups.google.com/group/bootstrap-datepicker/)
 * [Travis CI ![Build Status](https://travis-ci.org/eternicode/bootstrap-datepicker.svg?branch=master)](https://travis-ci.org/eternicode/bootstrap-datepicker)
 


### PR DESCRIPTION
@acrobat I think that the readme should lead people to the last stable docs instead to the dev docs. 
It might help avoid misunderstanding like in #1407.