### PR TITLE
Removed erroneous day highlighting after endDate

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -877,8 +877,7 @@
 				$.inArray(date.getUTCDay(), this.o.daysOfWeekDisabled) !== -1){
 				cls.push('disabled');
 			}
-			if (date.valueOf() < this.o.startDate || date.valueOf() > this.o.endDate ||
-				$.inArray(date.getUTCDay(), this.o.daysOfWeekHighlighted) !== -1){
+			if ($.inArray(date.getUTCDay(), this.o.daysOfWeekHighlighted) !== -1){
 				cls.push('highlighted');
 			}
 			if (this.o.datesDisabled.length > 0 &&

--- a/tests/suites/options.js
+++ b/tests/suites/options.js
@@ -524,6 +524,29 @@ test('DaysOfWeekHighlighted', function(){
     ok(target.hasClass('highlighted'), 'Day of week is highlighted');
 });
 
+test('Days before startDate and endDate are not highlighted', function(){
+    var input = $('<input />')
+                .appendTo('#qunit-fixture')
+                .val('2012-10-26')
+                .datepicker({
+                    format: 'yyyy-mm-dd',
+                    daysOfWeekHighlighted: '5',
+					startDate: '2012-10-26',
+                    endDate: '2012-10-26'
+                }),
+        dp = input.data('datepicker'),
+        picker = dp.picker,
+        target;
+
+
+    input.focus();
+    target = picker.find('.datepicker-days tbody td:nth(25)');
+    ok(!target.hasClass('highlighted'), 'Day before startDate is highlighted');
+    target = picker.find('.datepicker-days tbody td:nth(26)');
+    ok(target.hasClass('highlighted'), 'Day of week is not highlighted');
+    target = picker.find('.datepicker-days tbody td:nth(27)');
+    ok(!target.hasClass('highlighted'), 'Day after endDate is highlighted');
+});
 
 test('DatesDisabled', function(){
     var input = $('<input />')


### PR DESCRIPTION
When you set startDate or endDate value, disabled days become
highlighted. Bug was added in commit
77ea1ea1d3cfd4a44db88b63fe966f9a0bdf3919