### PR TITLE
Update json accordingly the latest definition

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,6 @@
   "name": "bootstrap-datepicker",
   "version": "1.4.1-dev",
   "main": [
-    "dist/css/bootstrap-datepicker.css",
     "dist/css/bootstrap-datepicker3.css",
     "dist/js/bootstrap-datepicker.min.js"
   ],


### PR DESCRIPTION
Bootstrap has done it. We as well. Update the bower.json file to only include one line per file type.
Only the main CSS file is listed then.

Ref: https://github.com/bower/bower.json-spec/pull/43