### PR TITLE
Update bootstrap-datepicker.js

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -1727,6 +1727,7 @@
 				setters_order = ['yyyy', 'yy', 'M', 'MM', 'm', 'mm', 'd', 'dd'],
 				setters_map = {
 					yyyy: function(d,v){
+					  if (v < 1000) v = 2000+v;
 						return d.setUTCFullYear(v);
 					},
 					yy: function(d,v){


### PR DESCRIPTION
If the specified format is yyyy but user enters an year using other digits, this is converted to 2XXX to respect the yyyy format.

f.e. 1 > 2001, 15 > 2015

Issues: #1457 #1446