### PR TITLE
feat(require): make requirable by adding index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,2 @@
+$ = jQuery = require('jquery');
+module.exports = require('./dist/js/bootstrap-datepicker.js');


### PR DESCRIPTION
This allows for requiring bootstrap-datepicker from other files using the syntax `require('bootstrap-datepicker')`, which will pull in the unminified source.