### PR TITLE
fix hiding

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -425,8 +425,7 @@
 							this.picker.find(e.target).length ||
 							this.picker.hasClass('datepicker-inline')
 						)){
-							$(this.picker).hide();
-							this._trigger('hide');
+							this.hide();
 						}
 					}, this)
 				}]


### PR DESCRIPTION
previously clicking on an element outside of the datepicker didn't go through the usual hide method, thus forceParse was ignored, leaving invalid dates in the input field