### PR TITLE
added setDatesDisabled method to documentation

### DIFF
--- a/docs/methods.rst
+++ b/docs/methods.rst
@@ -165,6 +165,18 @@ Sets a new upper date limit on the datepicker.  See :ref:`enddate` for valid val
 Omit endDate (or provide an otherwise falsey value) to unset the limit.
 
 
+setDatesDisabled
+----------------
+
+Arguments:
+
+* datesDisabled (String|Array)
+
+Sets the days that should be disabled.  See :ref:`datesDisabled` for valid values.
+
+Omit datesDisabled (or provide an otherwise falsey value) to unset the disabled days.
+
+
 setDaysOfWeekDisabled
 ---------------------
 


### PR DESCRIPTION
I was looking for a method to update the datesDisabled value.
Until I discovered that it had already implemented but not documented yet.