### PR TITLE
fix picker layout and orientation when rtl is true and input box is wide

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -697,20 +697,11 @@
 			else
 				top -= calendarHeight + parseInt(this.picker.css('padding-top'));
 
-			if (this.o.rtl) {
-				var right = windowWidth - (left + width);
-				this.picker.css({
-					top: top,
-					right: right,
-					zIndex: zIndex
-				});
-			} else {
-				this.picker.css({
-					top: top,
-					left: left,
-					zIndex: zIndex
-				});
-			}
+			this.picker.css({
+				top: top,
+				left: left,
+				zIndex: zIndex
+			});
 			return this;
 		},
 

--- a/less/datepicker.less
+++ b/less/datepicker.less
@@ -6,7 +6,9 @@
 	}
 	direction: ltr;
 	&&-rtl {
-		direction: rtl;
+		table {
+			direction: rtl;
+		}
 		table tr td span {
 			float: right;
 		}

--- a/less/datepicker3.less
+++ b/less/datepicker3.less
@@ -5,7 +5,9 @@
 	}
 	direction: ltr;
 	&&-rtl {
-		direction: rtl;
+		table {
+			direction: rtl;
+		}
 		table tr td span {
 			float: right;
 		}


### PR DESCRIPTION
Hi ,, 
There is a problem with datepicker and rtl option which result in white space next to the picker and orientation not working properly
check this jsfiddle 
    http://jsfiddle.net/Ahed91/g18gry8a/3/