### PR TITLE
Use date arithmetic to allow dates with times other than 00:00:00

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -60,7 +60,8 @@
 				// $.inArray doesn't work with Dates
 				var val = d && d.valueOf();
 				for (var i=0, l=this.length; i < l; i++)
-					if (this[i].valueOf() === val)
+          // Use date arithmetic to allow dates with different times to match
+          if (0 <= this[i].valueOf() - val && this[i].valueOf() - val < 1000*60*60*24)
 						return i;
 				return -1;
 			},

--- a/tests/suites/methods.js
+++ b/tests/suites/methods.js
@@ -44,6 +44,14 @@ test('update - Date', function(){
     strictEqual(returnedObject, this.dp, "is chainable");
 });
 
+test('update - Date with time', function(){
+    var returnedObject = this.dp.update(new Date(2012, 2, 13, 23, 59, 59, 999));
+    datesEqual(this.dp.dates[0], UTCDate(2012, 2, 13, 23, 59, 59, 999));
+    var date = this.dp.picker.find('.datepicker-days td:contains(13)');
+    ok(date.is('.active'), 'Date is selected');
+    strictEqual(returnedObject, this.dp, "is chainable");
+});
+
 test('update - null', function(){
     var returnedObject = this.dp.update(null);
     equal(this.dp.dates[0], undefined);


### PR DESCRIPTION
Instead of directly comparing date values using valueOf, dates are now compared with arithmetic to check if they fall under the same date. This fixes resolves #1221, allowing for times other than 00:00:00 when setting the date.