### PR TITLE
Fix bug on Range

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -1494,8 +1494,13 @@
 				return;
 			this.updating = true;
 
-			var dp = $(e.target).data('datepicker'),
-				new_date = dp.getUTCDate(),
+			var dp = $(e.target).data('datepicker');
+
+			if (typeof(dp) == "undefined") {
+				return;
+			}
+
+			var new_date = dp.getUTCDate(),
 				i = $.inArray(e.target, this.inputs),
 				j = i - 1,
 				k = i + 1,

--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -1496,7 +1496,7 @@
 
 			var dp = $(e.target).data('datepicker');
 
-			if (typeof(dp) == "undefined") {
+			if (typeof(dp) === "undefined") {
 				return;
 			}
 


### PR DESCRIPTION
If you want to init a datepicker (range or not) after remove a range one on the same input(s), an error was throw.

The case is if you want to dynamically change a range picker to a solo picker.

To test with the [online demo](http://eternicode.github.io/bootstrap-datepicker), choice range then run that in the console:
```js
$('#datepicker').datepicker('remove');
$('#datepicker input[name=start]').datepicker({});
```

I try many cases with remove (included call remove on each range children).

[EDIT] Forgot to say, the error is throw only if a value as been add to the input before removing range.