### PR TITLE
Add the zIndexOffset option to configure the dialog "height"

### DIFF
--- a/docs/options.rst
+++ b/docs/options.rst
@@ -363,3 +363,11 @@ Day of the week start. 0 (Sunday) to 6 (Saturday)
 
 .. figure:: _static/screenshots/option_weekstart.png
     :align: center
+
+
+zIndexOffset
+------------
+
+Integer.  Default: 10
+
+The CSS z-index of the open datepicker is the maximum z-index of the input and all of its DOM ancestors *plus* the ``zIndexOffset``.

--- a/docs/options.rst
+++ b/docs/options.rst
@@ -38,8 +38,9 @@ Function(Date).  Default: $.noop
 
 A function that takes a date as a parameter and returns a boolean indicating whether or not this month is selectable
 
+
 beforeShowYear
--------------
+--------------
 
 Function(Date).  Default: $.noop
 
@@ -54,6 +55,7 @@ A function that takes a date as a parameter and returns one of the following val
    * ``classes``: same as the String value above
    * ``tooltip``: a tooltip to apply to this year, via the ``title`` HTML attribute
 
+
 calendarWeeks
 -------------
 
@@ -63,6 +65,7 @@ Whether or not to show week numbers to the left of week rows.
 
 .. figure:: _static/screenshots/option_calendarweeks.png
     :align: center
+
 
 clearBtn
 --------
@@ -74,12 +77,6 @@ If true, displays a "Clear" button at the bottom of the datepicker to clear the 
 .. figure:: _static/screenshots/option_clearbtn.png
     :align: center
 
-toggleActive
-------------
-
-Boolean. Default: false
-
-If true, selecting the currently active date in the datepicker will unset the respective date. This option is always true when the multidate option is being used.
 
 container
 ---------
@@ -88,9 +85,18 @@ String.  Default: "body"
 
 Appends the date picker popup to a specific element; eg: container: '#picker-container' (will default to "body")
 
-
-
 .. _daysofweekdisabled:
+
+
+datesDisabled
+-------------
+
+String, Array.  Default: []
+
+Array of date strings or a single date string formatted in the given date format
+
+.. _defaultviewdate:
+
 
 daysOfWeekDisabled
 ------------------
@@ -104,6 +110,7 @@ Days of the week that should be disabled. Values are 0 (Sunday) to 6 (Saturday).
 
 .. _daysofweekhighlighted:
 
+
 daysOfWeekHighlighted
 ---------------------
 
@@ -112,15 +119,6 @@ String, Array.  Default: []
 Days of the week that should be highlighted. Values are 0 (Sunday) to 6 (Saturday). Multiple values should be comma-separated. Example: highlight weekends: ``06`` or ``'0,6'`` or ``[0,6]``.
 
 .. _datesdisabled:
-
-datesDisabled
--------------
-
-String, Array.  Default: []
-
-Array of date strings or a single date string formatted in the given date format
-
-.. _defaultviewdate:
 
 
 defaultViewDate
@@ -134,8 +132,24 @@ Date to view when initially opening the calendar. The internal value of the date
  * ``month``: 1
  * ``day``: 1
 
-
 .. _enddate:
+
+
+disableTouchKeyboard
+--------------------
+
+Boolean.  Default: false
+
+If true, no keyboard will show on mobile devices
+
+
+enableOnReadonly
+----------------
+
+Boolean. Default: true
+
+If false the datepicker will not show on a readonly datepicker field.
+
 
 endDate
 -------
@@ -148,10 +162,11 @@ The latest date that may be selected; all later dates will be disabled.
     :align: center
 
 .. code-block:: html
-  
+
     <input type="text" bootstrap-datepicker data-date-end-date="0d"/>
 
 Will disable all dates after today.
+
 
 forceParse
 ----------
@@ -173,6 +188,14 @@ The date format, combination of d, dd, D, DD, m, mm, M, MM, yy, yyyy.
 * m, mm: Numeric month, no leading zero and leading zero, respectively.  Eg, 7, 07.
 * M, MM: Abbreviated and full month names, respectively.  Eg, Jan, January
 * yy, yyyy: 2- and 4-digit years, respectively.  Eg, 12, 2012.
+
+
+immediateUpdates
+----------------
+
+Boolean. Default: false
+
+If true, selecting a year or month in the datepicker will update the input value immediately. Otherwise, only selecting a day of the month will update the input value immediately.
 
 
 inputs
@@ -213,6 +236,15 @@ The IETF code (eg  "en" for English, "pt-BR" for Brazilian Portuguese) of the la
     :align: center
 
 
+maxViewMode
+-----------
+
+Number, String.  Default: 2, "years"
+
+Set a maximum limit for the view mode.  Accepts: "days" or 0, "months" or 1, and "years" or 2.
+Gives the ability to pick only a day or a month.  The day is set to the 1st for "months", and the month is set to January for "years".
+
+
 minViewMode
 -----------
 
@@ -221,13 +253,6 @@ Number, String.  Default: 0, "days"
 Set a minimum limit for the view mode.  Accepts: "days" or 0, "months" or 1, and "years" or 2.
 Gives the ability to pick only a month or an year.  The day is set to the 1st for "months", and the month is set to January for "years".
 
-maxViewMode
------------
-
-Number, String.  Default: 2, "years"
-
-Set a maximum limit for the view mode.  Accepts: "days" or 0, "months" or 1, and "years" or 2.
-Gives the ability to pick only a day or a month.  The day is set to the 1st for "months", and the month is set to January for "years".
 
 multidate
 ---------
@@ -263,6 +288,15 @@ A space-separated string consisting of one or two of "left" or "right", "top" or
 
 .. _startdate:
 
+
+showOnFocus
+-----------
+
+Boolean.  Default: true
+
+If false, the datepicker will be prevented from showing when the input field associated with it receives focus.
+
+
 startDate
 ---------
 
@@ -281,12 +315,14 @@ Number, String.  Default: 0, "month"
 
 The view that the datepicker should show when it is opened.  Accepts values of 0 or "month" for month view (the default), 1 or "year" for the 12-month overview, and 2 or "decade" for the 10-year overview.  Useful for date-of-birth datepickers.
 
+
 title
---------
+-----
 
 String. Default: ""
 
 The string that will appear on top of the datepicker. If empty the title will be hidden.
+
 
 todayBtn
 --------
@@ -310,6 +346,14 @@ If true, highlights the current date.
     :align: center
 
 
+toggleActive
+------------
+
+Boolean. Default: false
+
+If true, selecting the currently active date in the datepicker will unset the respective date. This option is always true when the multidate option is being used.
+
+
 weekStart
 ---------
 
@@ -319,31 +363,3 @@ Day of the week start. 0 (Sunday) to 6 (Saturday)
 
 .. figure:: _static/screenshots/option_weekstart.png
     :align: center
-
-showOnFocus
------------
-
-Boolean.  Default: true
-
-If false, the datepicker will be prevented from showing when the input field associated with it receives focus.
-
-disableTouchKeyboard
---------------------
-
-Boolean.  Default: false
-
-If true, no keyboard will show on mobile devices
-
-enableOnReadonly
-----------------
-
-Boolean. Default: true
-
-If false the datepicker will not show on a readonly datepicker field.
-
-immediateUpdates
----------------------
-
-Boolean. Default: false
-
-If true, selecting a year or month in the datepicker will update the input value immediately. Otherwise, only selecting a day of the month will update the input value immediately.

--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -315,6 +315,7 @@
 				o.defaultViewDate = UTCToday();
 			}
 			o.showOnFocus = o.showOnFocus !== undefined ? o.showOnFocus : true;
+			o.zIndexOffset = o.zIndexOffset !== undefined ? o.zIndexOffset : 10;
 		},
 		_events: [],
 		_secondaryEvents: [],
@@ -683,7 +684,7 @@
 				var itemZIndex = $(this).css('z-index');
 				if (itemZIndex !== 'auto' && itemZIndex !== 0) parentsZindex.push(parseInt(itemZIndex));
 			});
-			var zIndex = Math.max.apply(Math, parentsZindex) + 10;
+			var zIndex = Math.max.apply(Math, parentsZindex) + this.o.zIndexOffset;
 			var offset = this.component ? this.component.parent().offset() : this.element.offset();
 			var height = this.component ? this.component.outerHeight(true) : this.element.outerHeight(false);
 			var width = this.component ? this.component.outerWidth(true) : this.element.outerWidth(false);

--- a/tests/suites/options.js
+++ b/tests/suites/options.js
@@ -1125,3 +1125,33 @@ test('i18n: Leverage English (default) i18n titleFormat when translation key for
     input.focus();
     equal(picker.find('.datepicker-days thead .datepicker-switch').text(), 'April 2015', 'Title is in default format: April 2015');
 }));
+
+test('Z-index Offset: none', function(){
+    var input = $('<input />')
+            .appendTo('#qunit-fixture')
+            .datepicker(),
+        dp = input.data('datepicker'),
+        picker = dp.picker;
+    input.parent().css('z-index', 234);
+
+    input.focus();
+
+    equal(dp.o.zIndexOffset, 10, 'Z-index offset option defaults to 10.');
+    equal(picker.css('z-index'), 244, 'Picker Z-index offset is respected.');
+});
+
+test('Z-index Offset: with value', function(){
+    var input = $('<input />')
+            .appendTo('#qunit-fixture')
+            .datepicker({
+                zIndexOffset: 1000
+            }),
+        dp = input.data('datepicker'),
+        picker = dp.picker;
+    input.parent().css('z-index', 234);
+
+    input.focus();
+
+    equal(dp.o.zIndexOffset, 1000, 'Z-index offset option is accepted.');
+    equal(picker.css('z-index'), 1234, 'Picker Z-index offset is respected.');
+});


### PR DESCRIPTION
Previously, the height was computed to be 10 higher than the max height of all of the input's parents. In some cases where the datepicker needs to move/scroll around with the page, it may collide with other fixed elements. In those cases, a configurable z-index is very helpful in order to keep the datepicker visible.

Please let me know if I should also be regenerating the `dist` assets as well. I couldn't infer from the contribution guidelines. Thank you!

![CSS](http://img.pandawhale.com/post-18529-Yes-mlkshk-1nAi.gif)

## TODO

* [x] Add tests asserting the behavior of a `zIndexOffset` option
* [x] Add the `zIndexOffset` option, making the test suite :green_heart:
* [x] Add documentation for the `zIndexOffset` option