### PR TITLE
Fixing month in title

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -922,7 +922,7 @@
 			if (isNaN(year) || isNaN(month))
 				return;
 			this.picker.find('.datepicker-days thead .datepicker-switch')
-						.text(DPGlobal.formatDate(new Date(year, month), titleFormat, this.o.language));
+						.text(DPGlobal.formatDate(d, titleFormat, this.o.language));
 			this.picker.find('tfoot .today')
 						.text(todaytxt)
 						.toggle(this.o.todayBtn !== false);


### PR DESCRIPTION
Using the viewDate for displaying month in title. In commit 67a2482691d6c253064d44a47f83cde7b21cd6e3, this line was changed to introduce improved translation. The old version used the variable "month" which is based on viewDate. The new version created a new Date at the start of the month.

In my timezone, +2, the result of new Date(2015, 7) is "Sat Aug 01 2015 00:00:00 GMT+0200 (W. Europe Daylight Time)".  DPGlobal.formatDate then uses date.getUTCMonth(), which is now 6 (instead of 7). This again mean that we end up with "July 2015" in the title.