### PR TITLE
forceParse = false doesn't apply on enter

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -1405,7 +1405,9 @@
 					// As such, its behavior should not be hijacked.
 					break;
 				case 13: // enter
-					if (!this.o.forceParse) break;
+					if (!this.o.forceParse) {
+							break;
+					}
 					focusDate = this.focusDate || this.dates.get(-1) || this.viewDate;
 					if (this.o.keyboardNavigation) {
 						this._toggle_multidate(focusDate);

--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -1405,6 +1405,7 @@
 					// As such, its behavior should not be hijacked.
 					break;
 				case 13: // enter
+					if (!this.o.forceParse) break;
 					focusDate = this.focusDate || this.dates.get(-1) || this.viewDate;
 					if (this.o.keyboardNavigation) {
 						this._toggle_multidate(focusDate);

--- a/tests/suites/options.js
+++ b/tests/suites/options.js
@@ -999,6 +999,36 @@ test('Immediate Updates', function(){
     equal(input.val(), '2015-02-01');
 });
 
+test('forceParse: false on enter on invalid date', function () {
+    var input = $('<input />')
+                .appendTo('#qunit-fixture')
+                .val('123456789')
+                .datepicker({forceParse: false})
+                .focus();
+
+    input.trigger({
+        type: 'keydown',
+        keyCode: 13,
+        shiftKey: false
+    });
+
+    equal(input.val(), '123456789', 'date not parsed');
+});
+
+test('forceParse: false on mousedown on invalid date', function () {
+    var input = $('<input />')
+                .appendTo('#qunit-fixture')
+                .val('123456789')
+                .datepicker({forceParse: false})
+                .focus();
+
+    $(document).trigger({
+        type: 'mousedown'
+    });
+
+    equal(input.val(), '123456789', 'date not parsed');
+});
+
 //datepicker-dropdown
 
 test('Enable on readonly options (default)', function(){


### PR DESCRIPTION
Sometimes our customers copy and paste dates from documents in the date fields, and hit enter after that. The regular forceParse setting does change that in a (sometimes completely wrong) valid  date, which then passes validation unnoticed. 
Setting forceParse to false should stop this behaviour, but it doesn't. (It works correctly on focus out, but not on enter), so we had to patch:

    $('[id$="_date_string"]').on('keydown', function(e){
        if (e.keyCode == 13){
          stopImmediatePropagation(e);
          return false;
        }}).datepicker({endDate: '+0d', forceParse: false});

It would be very nice if this behaviour was already in the library, as it is quite confusing to set forceParse to false and still have forced parsing on false...