### PR TITLE
Fix date-reset issue when navigating to next with invalid date

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -49,6 +49,9 @@
 			return this[method].apply(this, arguments);
 		};
 	}
+	function isValidDate(d) {
+		return d && !isNaN(d.getTime());
+	}
 
 	var DateArray = (function(){
 		var extras = {
@@ -1269,8 +1272,8 @@
 		},
 
 		moveMonth: function(date, dir){
-			if (!date)
-				return undefined;
+			if (!isValidDate(date))
+				return this.o.defaultViewDate;
 			if (!dir)
 				return date;
 			var new_date = new Date(date.valueOf()),

--- a/tests/suites/methods.js
+++ b/tests/suites/methods.js
@@ -121,3 +121,11 @@ test('place', function(){
     // ...
     strictEqual(returnedObject, this.dp, "is chainable");
 });
+
+test('moveMonth - can handle invalid date', function(){
+    // any input which results in an invalid date, f.e. an incorrectly formatted.
+    var invalidDate = new Date("invalid"),
+        returnedObject = this.dp.moveMonth(invalidDate, 1);
+    // ...
+    equal(returnedObject, undefined, "returnedObject");
+});

--- a/tests/suites/methods.js
+++ b/tests/suites/methods.js
@@ -127,5 +127,5 @@ test('moveMonth - can handle invalid date', function(){
     var invalidDate = new Date("invalid"),
         returnedObject = this.dp.moveMonth(invalidDate, 1);
     // ...
-    equal(returnedObject, undefined, "returnedObject");
+    equal(this.input.val(), "31-03-2011", "date is reset");
 });


### PR DESCRIPTION
When typing/pasting an invalid formatted date into the textbox (e.g. 2000-1-1 for a picker with mm/dd/yyyy) into a box, the browser will stall when clicking next.

I've traced the issue to the date-resetting loop in the moveMonth.
