### PR TITLE
Chage `fill` method call position

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -1248,11 +1248,11 @@
 			if (!which || which  === 'view')
 				this.viewDate = date && new Date(date);
 
-			this.fill();
 			this.setValue();
 			if (!which || which  !== 'view') {
 				this._trigger('changeDate');
 			}
+			this.fill();
 			var element;
 			if (this.isInput){
 				element = this.element;


### PR DESCRIPTION
I want add extra CSS classes to calendar cell with help of callback function of `beforeShowDay`, but there's a wrong method call order. 
Consequently, I suppose plugin must call `fill` method in this place like in other, other words `fill` method must be called only after `setValue` was called.