### PR TITLE
Added better year detection

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -1745,14 +1745,28 @@
 			}
 			parts = date && date.match(this.nonpunctuation) || [];
 			date = new Date();
+
+			function adjustYear(year){
+				// if year is 2 digits or less, than the user most likely is trying to get a recent century
+				if( year < 100 ){
+					year += 2000;
+					// if the new year is more than 10 years in advance, use last century
+					if( year > ((new Date()).getFullYear()+10) ){
+						year -= 100;
+					}
+				}
+
+				return year;
+			}
+
 			var parsed = {},
 				setters_order = ['yyyy', 'yy', 'M', 'MM', 'm', 'mm', 'd', 'dd'],
 				setters_map = {
 					yyyy: function(d,v){
-						return d.setUTCFullYear(v);
+						return d.setUTCFullYear(adjustYear(v));
 					},
 					yy: function(d,v){
-						return d.setUTCFullYear(2000+v);
+						return d.setUTCFullYear(adjustYear(v));
 					},
 					m: function(d,v){
 						if (isNaN(d))

--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -1748,10 +1748,10 @@
 
 			function adjustYear(year){
 				// if year is 2 digits or less, than the user most likely is trying to get a recent century
-				if( year < 100 ){
+				if (year < 100){
 					year += 2000;
 					// if the new year is more than 10 years in advance, use last century
-					if( year > ((new Date()).getFullYear()+10) ){
+					if (year > ((new Date()).getFullYear()+10)){
 						year -= 100;
 					}
 				}

--- a/tests/suites/formats.js
+++ b/tests/suites/formats.js
@@ -238,7 +238,7 @@ test('Invalid formats are force-parsed into a valid date on tab', patch_date(fun
         keyCode: 9
     });
 
-    equal(this.input.val(), '56-September-30');
+    equal(this.input.val(), '1956-September-30');
 }));
 
 test('Trailing separators', patch_date(function(Date){


### PR DESCRIPTION
I refactored the code to do better year detection. There are 2 changes:

* When a user enters a 2 digit year, the code now does a better job of guessing intent. If the 2 digit year is more than 10 years in the future, it'll use the past century instead. So in the 2015, a value between 00-25 would assume the century is 2000. For 26-99, it'll assume the user meant 1900 (e.g. 1/31/10 = Jan 31, 2010, 1/31/26 = Jan 31, 1926). People don't generally enter future dates too far in advance, but it's very common to enter dates from 50+ years ago.
* I changed the "yyyy" parse so that if the year is under 100, it assumes the user meant a 4 digit year. I can't think of a valid use case of when someone would really be entered Jan 1, 0015 as a date, but it's extremely common for users to enter a 2 digit year when a 4 digit year is asked for.

Hopefully you find this changes useful.