### PR TITLE
added keepEmptyValues option

### DIFF
--- a/docs/options.rst
+++ b/docs/options.rst
@@ -284,6 +284,14 @@ Boolean. Default: false
 If true, selecting a year or month in the datepicker will update the input value immediately. Otherwise, only selecting a day of the month will update the input value immediately.
 
 
+keepEmptyValues
+---------------
+
+Boolean. Default: false
+
+Only effective in a range picker. If true, the selected value does not get propagated to other, currently empty, pickers in the range.
+
+
 inputs
 ------
 

--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -1581,6 +1581,9 @@
 		});
 		delete options.inputs;
 
+		this.keepEmptyValues = options.keepEmptyValues || false;
+		delete options.keepEmptyValues;
+
 		datepickerPlugin.call($(this.inputs), options)
 			.on('changeDate', $.proxy(this.dateUpdated, this));
 
@@ -1619,6 +1622,7 @@
 			}
 
 			var new_date = dp.getUTCDate(),
+				keep_empty_values = this.keepEmptyValues,
 				i = $.inArray(e.target, this.inputs),
 				j = i - 1,
 				k = i + 1,
@@ -1627,7 +1631,7 @@
 				return;
 
 			$.each(this.pickers, function(i, p){
-				if (!p.getUTCDate())
+				if (!p.getUTCDate() && (p === dp || !keep_empty_values))
 					p.setUTCDate(new_date);
 			});
 

--- a/tests/suites/options.js
+++ b/tests/suites/options.js
@@ -1512,3 +1512,32 @@ test('date cells', function(){
         ok(this.hasAttribute('data-date'));
     });
 });
+
+test('keepEmptyValues: none (default is false)', function() {
+    var proxy_element = $('<div />').appendTo('#qunit-fixture'),
+        input_from = $('<input />').appendTo('#qunit-fixture'),
+        input_to = $('<input />').appendTo('#qunit-fixture'),
+        dp = proxy_element.datepicker({
+            inputs: [input_from, input_to]
+        });
+
+    input_from.val('2012-03-05');
+    input_from.datepicker('setValue');
+
+    equal(input_to.val(), input_from.val(), 'Input_from value should be distributed.');
+});
+
+test('keepEmptyValues: true', function() {
+    var proxy_element = $('<div />').appendTo('#qunit-fixture'),
+        input_from = $('<input />').appendTo('#qunit-fixture'),
+        input_to = $('<input />').appendTo('#qunit-fixture'),
+        dp = proxy_element.datepicker({
+            inputs: [input_from, input_to],
+            keepEmptyValues: true
+        });
+
+    input_from.val('2012-03-05');
+    input_from.datepicker('setValue');
+
+    equal(input_to.val(), '', 'Input_from value should NOT be distributed.');
+});


### PR DESCRIPTION
If this option is set to true, it will stop propagation of a selected
date to other, currently empty, pickers in a date range setup.

Default for this option is false, to keep the current behavior.

fixes #1454 