### PR TITLE
Correct default month value of defaultViewDate in Doc.

### DIFF
--- a/docs/options.rst
+++ b/docs/options.rst
@@ -129,7 +129,7 @@ Object with keys ``year``, ``month``, and ``day``. Default: today
 Date to view when initially opening the calendar. The internal value of the date remains today as default, but when the datepicker is first opened the calendar will open to ``defaultViewDate`` rather than today. If this option is not used, "today" remains the default view date. If the given object is missing any of the required keys, their defaults are:
 
  * ``year``: the current year
- * ``month``: 1
+ * ``month``: 0
  * ``day``: 1
 
 .. _enddate:


### PR DESCRIPTION
Fixed error in document. Month begins from 0, which was quite confusing.