### PR TITLE
Fix an issue with clicking outside a span, td, or th

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -1117,7 +1117,7 @@
 			e.stopPropagation();
 			var target = $(e.target).closest('span, td, th'),
 				year, month, day;
-			if (target.length === 1){
+			if (target.length === 1 && $.contains(this.picker.get(0), target.get(0))){
 				switch (target[0].nodeName.toLowerCase()){
 					case 'th':
 						switch (target[0].className){


### PR DESCRIPTION
The click handler will search for the closest ancestor that is a span, td, or th. This will sometimes find an element outside the picker itself and treat it as a datepicker control, which will result in setting the year to zero.

To see this bug in action, wrap the picker in a span, set a startDate, and in the "month" view, click on the place where a "<<" button would normaly be.

This fix adds a simple check that the target is actually inside the datepicker.