### PR TITLE
Fix datepicker title not centered when displaying calendar weeks

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -132,7 +132,7 @@
 		this.viewMode = this.o.startView;
 
 		if (this.o.calendarWeeks)
-			this.picker.find('tfoot .today, tfoot .clear')
+			this.picker.find('thead .datepicker-title, tfoot .today, tfoot .clear')
 						.attr('colspan', function(i, val){
 							return parseInt(val) + 1;
 						});


### PR DESCRIPTION
This pull requests fixes bug #1625. The fix is trivial and makes use of an existing feature; the potential for a regression is minimal.

Cheers, Oliver