### PR TITLE
Add "assumeNearbyYear" option

### DIFF
--- a/docs/options.rst
+++ b/docs/options.rst
@@ -176,6 +176,17 @@ Boolean.  Default: true
 Whether or not to force parsing of the input value when the picker is closed.  That is, when an invalid date is left in the input field by the user, the picker will forcibly parse that value, and set the input's value to the new, valid date, conforming to the given `format`.
 
 
+assumeNearbyYear
+
+----------
+
+Boolean or Integer.  Default: false
+
+If true, manually-entered dates with two-digit years, such as "5/1/15", will be parsed as "2015", not "15". If the year is less than 10 years in advance, the picker will use the current century, otherwise, it will use the previous one. For example "5/1/15" would parse to May 1st, 2015, but "5/1/97" would be May 1st, 1997.
+
+To configure the number of years in advance that the picker will still use the current century, use an Integer instead of the Boolean true. E.g. "assumeNearbyYear: 20"
+
+
 format
 ------
 

--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -236,7 +236,7 @@
 					if (o.startDate instanceof Date)
 						o.startDate = this._local_to_utc(this._zero_time(o.startDate));
 					else
-						o.startDate = DPGlobal.parseDate(o.startDate, format, o.language);
+						o.startDate = DPGlobal.parseDate(o.startDate, format, o.language, o.assumeNearbyYear);
 				}
 				else {
 					o.startDate = -Infinity;
@@ -247,7 +247,7 @@
 					if (o.endDate instanceof Date)
 						o.endDate = this._local_to_utc(this._zero_time(o.endDate));
 					else
-						o.endDate = DPGlobal.parseDate(o.endDate, format, o.language);
+						o.endDate = DPGlobal.parseDate(o.endDate, format, o.language, o.assumeNearbyYear);
 				}
 				else {
 					o.endDate = Infinity;
@@ -271,11 +271,11 @@
 			o.datesDisabled = o.datesDisabled||[];
 			if (!$.isArray(o.datesDisabled)) {
 				var datesDisabled = [];
-				datesDisabled.push(DPGlobal.parseDate(o.datesDisabled, format, o.language));
+				datesDisabled.push(DPGlobal.parseDate(o.datesDisabled, format, o.language, o.assumeNearbyYear));
 				o.datesDisabled = datesDisabled;
 			}
 			o.datesDisabled = $.map(o.datesDisabled,function(d){
-				return DPGlobal.parseDate(d, format, o.language);
+				return DPGlobal.parseDate(d, format, o.language, o.assumeNearbyYear);
 			});
 
 			var plc = String(o.orientation).toLowerCase().split(/\s+/g),
@@ -780,7 +780,7 @@
 			}
 
 			dates = $.map(dates, $.proxy(function(date){
-				return DPGlobal.parseDate(date, this.o.format, this.o.language);
+				return DPGlobal.parseDate(date, this.o.format, this.o.language, this.o.assumeNearbyYear);
 			}, this));
 			dates = $.grep(dates, $.proxy(function(date){
 				return (
@@ -1630,6 +1630,7 @@
 	$.fn.datepicker = datepickerPlugin;
 
 	var defaults = $.fn.datepicker.defaults = {
+		assumeNearbyYear: false,
 		autoclose: false,
 		beforeShowDay: $.noop,
 		beforeShowMonth: $.noop,
@@ -1718,7 +1719,7 @@
 			}
 			return {separators: separators, parts: parts};
 		},
-		parseDate: function(date, format, language){
+		parseDate: function(date, format, language, assumeNearby){
 			if (!date)
 				return undefined;
 			if (date instanceof Date)
@@ -1754,14 +1755,31 @@
 			}
 			parts = date && date.match(this.nonpunctuation) || [];
 			date = new Date();
+
+			function applyNearbyYear(year, threshold){
+				if (threshold === true)
+					threshold = 10;
+
+				// if year is 2 digits or less, than the user most likely is trying to get a recent century
+				if (year < 100){
+					year += 2000;
+					// if the new year is more than threshold years in advance, use last century
+					if (year > ((new Date()).getFullYear()+threshold)){
+						year -= 100;
+					}
+				}
+
+				return year;
+			}
+
 			var parsed = {},
 				setters_order = ['yyyy', 'yy', 'M', 'MM', 'm', 'mm', 'd', 'dd'],
 				setters_map = {
 					yyyy: function(d,v){
-						return d.setUTCFullYear(v);
+						return d.setUTCFullYear(assumeNearby ? applyNearbyYear(v, assumeNearby) : v);
 					},
 					yy: function(d,v){
-						return d.setUTCFullYear(2000+v);
+						return d.setUTCFullYear(assumeNearby ? applyNearbyYear(v, assumeNearby) : v);
 					},
 					m: function(d,v){
 						if (isNaN(d))

--- a/tests/suites/formats.js
+++ b/tests/suites/formats.js
@@ -249,3 +249,48 @@ test('Trailing separators', patch_date(function(Date){
         .datepicker('setValue');
     equal(this.input.val(), '29.02.2012.');
 }));
+
+test('Assume nearby year - last century', patch_date(function(Date){
+    Date.now = UTCDate(2012, 4, 31);
+    this.input
+        .val('02/14/91')
+        .datepicker({format: 'mm/dd/yyyy', assumeNearbyYear: true})
+        .datepicker('setValue');
+    equal(this.input.val(), '02/14/1991');
+}));
+
+test('Assume nearby year - this century (- 1 year)', patch_date(function(Date){
+    Date.now = UTCDate(2012, 4, 31);
+    this.input
+        .val('02/14/01')
+        .datepicker({format: 'mm/dd/yyyy', assumeNearbyYear: true})
+        .datepicker('setValue');
+    equal(this.input.val(), '02/14/2001');
+}));
+
+test('Assume nearby year - this century (+ 7 years)', patch_date(function(Date){
+    Date.now = UTCDate(2012, 4, 31);
+    this.input
+        .val('02/14/19')
+        .datepicker({format: 'mm/dd/yyyy', assumeNearbyYear: true})
+        .datepicker('setValue');
+    equal(this.input.val(), '02/14/2019');
+}));
+
+test('Assume nearby year - this century (+ 13 years)', patch_date(function(Date){
+    Date.now = UTCDate(2012, 4, 31);
+    this.input
+        .val('02/14/23')
+        .datepicker({format: 'mm/dd/yyyy', assumeNearbyYear: true})
+        .datepicker('setValue');
+    equal(this.input.val(), '02/14/1923');
+}));
+
+test('Assume nearby year - this century (+ 13 years, threshold = 30)', patch_date(function(Date){
+    Date.now = UTCDate(2012, 4, 31);
+    this.input
+        .val('02/14/23')
+        .datepicker({format: 'mm/dd/yyyy', assumeNearbyYear: 30})
+        .datepicker('setValue');
+    equal(this.input.val(), '02/14/2023');
+}));


### PR DESCRIPTION
Rebase / modification of #1556. My hope is that this can be merged.

If the user opts-in by setting `options.assumeNearbyYear` = true:

- When a user enters a 2 digit year, the code now does a better job of
guessing intent. If the 2 digit year is more than 10 years in the future,
it'll use the past century instead. So in the 2015, a value between 00-25
would assume the century is 2000. For 26-99, it'll assume the user meant
1900 (e.g. 1/31/10 = Jan 31, 2010, 1/31/26 = Jan 31, 1926). People don't
generally enter future dates too far in advance, but it's very common
to enter dates from 50+ years ago.