### PR TITLE
Use document scrollTop instead of body scrollTop when using the body container

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -678,7 +678,7 @@
 				visualPadding = 10,
 				container = $(this.o.container),
 				windowWidth = container.width(),
-				scrollTop = container.scrollTop(),
+				scrollTop = this.o.container === 'body' ? $(document).scrollTop() : container.scrollTop(),
 				appendOffset = container.offset();
 
 			var parentsZindex = [];


### PR DESCRIPTION
Not sure if this has been discussed before, but couldn't find anything when searching. Apologies if I missed it.

Using `$('body').scrollTop()` yields different results in Chrome / FF [as you can see here](http://stackoverflow.com/questions/12941150/scrolltop-returns-0-in-firefox-but-not-in-chrome). The method always returns `0` on FF, which messes up the automatic placement calculation. Using `$(document).scrollTop()` solves the issue.

Thanks!
