### PR TITLE
Changes nonpunctuation to accept unicode characters

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -1705,7 +1705,7 @@
 			return [31, (DPGlobal.isLeapYear(year) ? 29 : 28), 31, 30, 31, 30, 31, 31, 30, 31, 30, 31][month];
 		},
 		validParts: /dd?|DD?|mm?|MM?|yy(?:yy)?/g,
-		nonpunctuation: /[^ -\/:-@\[\u3400-\u9fff-`{-~\t\n\r]+/g,
+		nonpunctuation: /[^ -\/:-@\u5e74\u6708\u65e5\[-`{-~\t\n\r]+/g,
 		parseFormat: function(format){
 			if (typeof format.toValue === 'function' && typeof format.toDisplay === 'function')
                 return format;

--- a/tests/suites/methods.js
+++ b/tests/suites/methods.js
@@ -129,3 +129,24 @@ test('moveMonth - can handle invalid date', function(){
     // ...
     equal(this.input.val(), "31-03-2011", "date is reset");
 });
+
+test('parseDate - outputs correct value', function(){
+    var parsedDate = $.fn.datepicker.DPGlobal.parseDate('11/13/2015',$.fn.datepicker.DPGlobal.parseFormat('mm/dd/yyyy'),'en');
+    equal(parsedDate.getDate(), "13", "date is correct");
+    equal(parsedDate.getMonth(), "10", "month is correct");
+    equal(parsedDate.getFullYear(), "2015", "fullyear is correct");
+});
+
+test('parseDate - outputs correct value for yyyy\u5E74mm\u6708dd\u65E5 format', function(){
+    var parsedDate = $.fn.datepicker.DPGlobal.parseDate('2015\u5E7411\u670813',$.fn.datepicker.DPGlobal.parseFormat('yyyy\u5E74mm\u6708dd\u65E5'),'ja');
+    equal(parsedDate.getDate(), "13", "date is correct");
+    equal(parsedDate.getMonth(), "10", "month is correct");
+    equal(parsedDate.getFullYear(), "2015", "fullyear is correct");
+});
+
+test('parseDate - outputs correct value for dates containing unicodes', function(){
+    var parsedDate = $.fn.datepicker.DPGlobal.parseDate('\u5341\u4E00\u6708 13 2015',$.fn.datepicker.DPGlobal.parseFormat('MM dd yyyy'),'zh-CN');
+    equal(parsedDate.getDate(), "13", "date is correct");
+    equal(parsedDate.getMonth(), "10", "month is correct");
+    equal(parsedDate.getFullYear(), "2015", "fullyear is correct");
+});


### PR DESCRIPTION
Rejecting Unicode characters in `nonpunctuation` is added in #294 to support yyyy年mm月dd format. However rejecting all Unicode in the range \u3400 to \u9fff rejects names of Chinese months too. And calling parseDate with Chinese date having the month format as  MM results in today's date always irrespective of the date passed. Hence don't reject all the Unicode and reject only the three Unicode in Japanese date format.