### PR TITLE
Export datepicker function if CommonJS module

### DIFF
--- a/js/.jshintrc
+++ b/js/.jshintrc
@@ -3,7 +3,8 @@
     "predef" : [
       "require",
       "define",
-      "escape"
+      "escape",
+      "module"
     ],
     "jquery": true,
     "browser": true,

--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -23,8 +23,8 @@
 (function(factory){
     if (typeof define === "function" && define.amd) {
         define(["jquery"], factory);
-    } else if (typeof exports === 'object') {
-        factory(require('jquery'));
+    } else if (typeof module !== 'undefined' && module.exports) {
+        module.exports = factory;
     } else {
         factory(jQuery);
     }


### PR DESCRIPTION
Add the factory function to module.exports, so that an instance of jQuery can be passed when the module is require'd in a CommonJS environment. The current apporach doesn't seem to work as jQuery creates a new instance for every time it is require'd.