### PR TITLE
Adding dateCells option

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -1062,7 +1062,8 @@
 				}
 
 				clsName = $.unique(clsName);
-				html.push('<td class="'+clsName.join(' ')+'"' + (tooltip ? ' title="'+tooltip+'"' : '') + '>'+prevMonth.getUTCDate() + '</td>');
+				
+				html.push('<td class="'+clsName.join(' ')+'"' + (tooltip ? ' title="'+tooltip+'"' : '') + (this.o.dateCells ? ' data-date="'+(prevMonth.getTime().toString())+'"' : '') + '>'+prevMonth.getUTCDate() + '</td>');
 				tooltip = null;
 				if (prevMonth.getUTCDay() === this.o.weekEnd){
 					html.push('</tr>');
@@ -1761,6 +1762,7 @@
 		enableOnReadonly: true,
 		container: 'body',
 		immediateUpdates: false,
+		dateCells:false,
 		title: '',
 		templates: {
 			leftArrow: '<span class="glyphicon glyphicon-arrow-left"></span>',

--- a/tests/suites/options.js
+++ b/tests/suites/options.js
@@ -1426,3 +1426,20 @@ test('templates', function(){
     equal(picker.find('.datepicker-days .prev').prop('innerHTML'), $('<div>').html('&laquo;').text());
     equal(picker.find('.datepicker-days .next').prop('innerHTML'), '<span class="glyphicon glyphicon-arrow-right"></span>');
 });
+
+test('date cells', function(){
+    var input = $('<input />')
+                .appendTo('#qunit-fixture')
+                .val('2012-03-05')
+                .datepicker({
+                    dateCells: true
+                }),
+        dp = input.data('datepicker'),
+        picker = dp.picker,
+        target;
+
+        input.focus();
+		picker.find('.datepicker-days .day').each(function(){
+			ok($(this)[0].hasAttribute('data-date'))
+		});
+});


### PR DESCRIPTION
Adds an option to add a data-date attribute with a timestamp representative of that cell's date. This makes bootstrap-datepicker more extensible when using callbacks.

![](http://j4p.us/2v0M3J0n4327/Screen%20Shot%202015-12-17%20at%203.35.43%20PM.png)

Have not run
`grunt dist`

Added unit tests as well.
![](http://j4p.us/2P1Y102p3U3G/Screen%20Shot%202015-12-17%20at%204.07.09%20PM.png)