### PR TITLE
Fix default arrows for BS2 and screenshots (for docs)

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -42,7 +42,7 @@ Usage
 
 Call the datepicker via javascript::
 
-    $('.datepicker').datepicker()
+    $('.datepicker').datepicker();
 
 
 Data API
@@ -78,7 +78,7 @@ Configuration
     $('.datepicker').datepicker({
         format: 'mm/dd/yyyy',
         startDate: '-3d'
-    })
+    });
 
 Most options may be provided as data-attributes on the target element:
 
@@ -90,14 +90,14 @@ Most options may be provided as data-attributes on the target element:
 
     $('.datepicker').datepicker({
         startDate: '-3d'
-    })
+    });
 
 Defaults for all options can be modified directly by changing values in the ``$.fn.datepicker.defaults`` hash::
 
     $.fn.datepicker.defaults.format = "mm/dd/yyyy";
     $('.datepicker').datepicker({
         startDate: '-3d'
-    })
+    });
 
 
 Stylesheets

--- a/docs/options.rst
+++ b/docs/options.rst
@@ -244,26 +244,26 @@ Custom formatting options
 ::
 
     $('.datepicker').datepicker({
-            format: {
-                /*
-                Say our UI should display a week ahead,
-                but textbox should store the actual date.
-                This is useful if we need UI to select local dates,
-                but store in UTC
-                */
-                toDisplay: function (date, format, language) {
-                    var d = new Date(date);
-                    d.setDate(d.getDate() - 7);
-                    return d.toISOString();
-                },
-                toValue: function (date, format, language) {
-                    var d = new Date(date);
-                    d.setDate(d.getDate() + 7);
-                    return new Date(d);
-                }
+        format: {
+            /*
+             * Say our UI should display a week ahead,
+             * but textbox should store the actual date.
+             * This is useful if we need UI to select local dates,
+             * but store in UTC
+             */
+            toDisplay: function (date, format, language) {
+                var d = new Date(date);
+                d.setDate(d.getDate() - 7);
+                return d.toISOString();
             },
-            autoclose: true
-        });
+            toValue: function (date, format, language) {
+                var d = new Date(date);
+                d.setDate(d.getDate() + 7);
+                return new Date(d);
+            }
+        },
+        autoclose: true
+    });
 
 
 immediateUpdates
@@ -284,14 +284,14 @@ A list of inputs to be used in a range picker, which will be attached to the sel
 .. code-block:: html
 
     <div class="form-group form-group-filled" id="event_period">
-       <input type="text" class="actual_range">
-       <input type="text" class="actual_range">
+        <input type="text" class="actual_range">
+        <input type="text" class="actual_range">
     </div>
 
 ::
 
     $('#event_period').datepicker({
-       inputs: $('.actual_range')
+        inputs: $('.actual_range')
     });
 
 
@@ -398,13 +398,19 @@ templates
 ---------
 
 Object. Default:
+
+::
+
     {
-        leftArrow: '<span class="glyphicon glyphicon-arrow-left"></span>',
-        rightArrow: '<span class="glyphicon glyphicon-arrow-right"></span>'
+        leftArrow: '&laquo;',
+        rightArrow: '&raquo;'
     }
 
 The templates used to generate some parts of the picker. Each property must be a string with only text, or valid html.
-You can use this property to use custom icons libs. for example :
+You can use this property to use custom icons libs. for example:
+
+::
+
     {
         leftArrow: '<i class="fa fa-long-arrow-left"></i>',
         rightArrow: '<i class="fa fa-long-arrow-right"></i>'

--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -1796,8 +1796,8 @@
 		immediateUpdates: false,
 		title: '',
 		templates: {
-			leftArrow: '<span class="glyphicon glyphicon-arrow-left"></span>',
-			rightArrow: '<span class="glyphicon glyphicon-arrow-right"></span>'
+			leftArrow: '&laquo;',
+			rightArrow: '&raquo;'
 		}
 	};
 	var locale_opts = $.fn.datepicker.locale_opts = [
@@ -2042,9 +2042,9 @@
 			                '<th colspan="7" class="datepicker-title"></th>'+
 			              '</tr>'+
 							'<tr>'+
-								'<th class="prev"><span class="glyphicon glyphicon-arrow-left"></span></th>'+
+								'<th class="prev">&laquo;</th>'+
 								'<th colspan="5" class="datepicker-switch"></th>'+
-								'<th class="next"><span class="glyphicon glyphicon-arrow-right"></span></th>'+
+								'<th class="next">&raquo;</th>'+
 							'</tr>'+
 						'</thead>',
 		contTemplate: '<tbody><tr><td colspan="7"></td></tr></tbody>',

--- a/tests/suites/options.js
+++ b/tests/suites/options.js
@@ -1415,7 +1415,7 @@ test('templates', function(){
             .appendTo('#qunit-fixture')
             .datepicker({
                 templates: {
-                    leftArrow: '&laquo;',
+                    leftArrow: '<span class="glyphicon glyphicon-arrow-left"></span>',
                     rightArrow: '</table>'
                 }
             }),
@@ -1423,6 +1423,6 @@ test('templates', function(){
         picker = dp.picker;
 
     input.focus();
-    equal(picker.find('.datepicker-days .prev').prop('innerHTML'), $('<div>').html('&laquo;').text());
-    equal(picker.find('.datepicker-days .next').prop('innerHTML'), '<span class="glyphicon glyphicon-arrow-right"></span>');
+    equal(picker.find('.datepicker-days .prev').prop('innerHTML'), '<span class="glyphicon glyphicon-arrow-left"></span>');
+    equal(picker.find('.datepicker-days .next').prop('innerHTML'), $('<div>').html('&raquo;').text());
 });


### PR DESCRIPTION
1. Highlighted `templates` options and indent unification (4 whitespace).
2. Fix screenshot and default arrows for Bootstrap 2 (still support).

For reproduce open `/docs/_screenshots/demo_head.html` and write `setup()` in console.
