### PR TITLE
Fix bug:1. function parseDate when date parts is more than format parts.

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -1967,9 +1967,13 @@
 			var fparts = format.parts.slice();
 			// Remove noop parts
 			if (parts.length !== fparts.length){
-				fparts = $(fparts).filter(function(i,p){
-					return $.inArray(p, setters_order) !== -1;
-				}).toArray();
+				if (parts.length < fparts.length){
+                    fparts = $(fparts).filter(function(i, p){
+                        return $.inArray(p, setters_order) !== -1;
+                    }).toArray();
+                } else {
+                    parts = parts.slice(0, fparts.length);
+                }
 			}
 			// Process remainder
 			function match_part(){


### PR DESCRIPTION
When default endDate is set to ‘2022-12-12’ and format is set to ‘yyyy’, the endDate is parsed to current day which is not expected result.