### PR TITLE
Major bug in docs.

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -58,8 +58,8 @@ Markup with component
 
 .. code-block:: html
 
-    <div class="input-group date" data-provide="datepicker">
-        <input type="text" class="form-control">
+    <div class="input-group date">
+        <input type="text" class="form-control" data-provide="datepicker">
         <div class="input-group-addon">
             <span class="glyphicon glyphicon-th"></span>
         </div>


### PR DESCRIPTION
This absolutely didn't work for me on the parent div. In fact, on the parent div `data-provide="datepicker"` makes it such that clicking the day does not result in the date actually being placed into the input box.