### PR TITLE
Extend beforeShowMonth event functionality to work like beforeShowDay and beforeShowYear

### DIFF
--- a/docs/options.rst
+++ b/docs/options.rst
@@ -37,7 +37,16 @@ beforeShowMonth
 
 Function(Date).  Default: $.noop
 
-A function that takes a date as a parameter and returns a boolean indicating whether or not this month is selectable
+A function that takes a date as a parameter and returns one of the following values:
+
+ * undefined to have no effect
+ * A Boolean, indicating whether or not this month is selectable
+ * A String representing additional CSS classes to apply to the month's cell
+ * An object with the following properties:
+
+   * ``enabled``: same as the Boolean value above
+   * ``classes``: same as the String value above
+   * ``tooltip``: a tooltip to apply to this date, via the ``title`` HTML attribute
 
 
 beforeShowYear

--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -1103,12 +1103,20 @@
 			if (this.o.beforeShowMonth !== $.noop){
 				var that = this;
 				$.each(months, function(i, month){
-					if (!$(month).hasClass('disabled')) {
-						var moDate = new Date(year, i, 1);
-						var before = that.o.beforeShowMonth(moDate);
-						if (before === false)
-							$(month).addClass('disabled');
-					}
+          var moDate = new Date(year, i, 1);
+          var before = that.o.beforeShowMonth(moDate);
+					if (before === undefined)
+						before = {};
+					else if (typeof(before) === 'boolean')
+						before = {enabled: before};
+					else if (typeof(before) === 'string')
+						before = {classes: before};
+					if (before.enabled === false && !$(month).hasClass('disabled'))
+					    $(month).addClass('disabled');
+					if (before.classes)
+					    $(month).addClass(before.classes);
+					if (before.tooltip)
+					    $(month).prop('title', before.tooltip);
 				});
 			}
 

--- a/tests/suites/options.js
+++ b/tests/suites/options.js
@@ -736,6 +736,53 @@ test('BeforeShowDay', function(){
     ok(!target.hasClass('disabled'), '29th is enabled');
 });
 
+
+test('BeforeShowMonth', function () {
+
+    var beforeShowMonth = function (date) {
+        switch (date.getMonth()()) {
+            case 0:
+                return {
+                    tooltip: 'Example tooltip',
+                    classes: 'active'
+                };
+            case 2:
+                return "testMarch";
+            case 4:
+                return {enabled: false, classes: 'testMay'};
+            case 5:
+                return false;
+        }
+    };
+
+    var input = $('<input />')
+            .appendTo('#qunit-fixture')
+            .val('2012-10-26')
+            .datepicker({
+                format: 'yyyy-mm-dd',
+                beforeShowMonth: beforeShowMonth
+            }),
+        dp = input.data('datepicker'),
+        picker = dp.picker,
+        target;
+
+    input.focus();
+    target = picker.find('.datepicker-months tbody span:nth(0)');
+    equal(target.attr('title'), 'Example tooltip', '1st has tooltip');
+    ok(!target.hasClass('disabled'), 'January is enabled');
+    target = picker.find('.datepicker-months tbody span:nth(2)');
+    ok(target.hasClass('testMarch'), 'March has testMarch class');
+    ok(!target.hasClass('disabled'), 'March enabled');
+    target = picker.find('.datepicker-months tbody span:nth(4)');
+    ok(target.hasClass('testMay'), 'May has testMay class');
+    ok(target.hasClass('disabled'), 'May is disabled');
+    target = picker.find('.datepicker-months tbody span:nth(5)');
+    ok(target.hasClass('disabled'), 'June is disabled');
+    target = picker.find('.datepicker-months tbody span:nth(6)');
+    ok(!target.hasClass('disabled'), 'July is enabled');
+});
+
+
 test('BeforeShowYear', function () {
 
     var beforeShowYear = function (date) {

--- a/tests/suites/options.js
+++ b/tests/suites/options.js
@@ -740,7 +740,7 @@ test('BeforeShowDay', function(){
 test('BeforeShowMonth', function () {
 
     var beforeShowMonth = function (date) {
-        switch (date.getMonth()()) {
+        switch (date.getMonth()) {
             case 0:
                 return {
                     tooltip: 'Example tooltip',


### PR DESCRIPTION
The event `beforeShowMonth` could only disable the cells.
I extended it with the functionality of `beforeShowDay` so you can disable, add classes and set a tooltip.
Backwards compatibility is given.

Tests are added and documentation is extended.