### PR TITLE
Add options to customise datepicker popup with user defined class

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -134,6 +134,11 @@
 		else {
 			this.picker.addClass('datepicker-dropdown dropdown-menu');
 		}
+		
+		if (options.class)
+    {
+      this.picker.addClass(options.class);
+    }
 
 		if (this.o.rtl){
 			this.picker.addClass('datepicker-rtl');

--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -136,7 +136,7 @@
 		}
 		
 		if (this.o.class){
-      this.picker.addClass(options.class);
+      this.picker.addClass(this.o.class);
     }
 
 		if (this.o.rtl){

--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -135,8 +135,7 @@
 			this.picker.addClass('datepicker-dropdown dropdown-menu');
 		}
 		
-		if (options.class)
-    {
+		if (this.o.class){
       this.picker.addClass(options.class);
     }
 


### PR DESCRIPTION
This options will be extremely useful when there is a need to have 2 date pickers with different styles on one page (like different styles for date range pickers). That way it is possible to override bootstrap styles not globally, but only for specific page/usage.