### PR TITLE
originalEvent object needs preventDefault fn

### DIFF
--- a/tests/suites/events.js
+++ b/tests/suites/events.js
@@ -313,7 +313,9 @@ test('paste must update the date', function() {
             clipboardData: {
                 types: ['text/plain'],
                 getData: function() { return dateToPaste; }
-            }
+            },
+            preventDefault: function() { evt.originalEvent.isDefaultPrevented = true; },
+            isDefaultPrevented: false
         }
     };
     this.input.trigger(evt);


### PR DESCRIPTION
preventDefault function expected by jQuery 2.2.1

not sure if:

    ok(evt.originalEvent.isDefaultPrevented, 'prevented original event');

should be added to test.