### PR TITLE
Fix jQuery selector from premature selection of span element in inline/embedded calendar's month selection

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -1087,7 +1087,7 @@
 						.find('.datepicker-switch')
 							.text(this.o.maxViewMode < 2 ? monthsTitle : year)
 							.end()
-						.find('span').removeClass('active');
+						.find('tbody span').removeClass('active');
 
 			$.each(this.dates, function(i, d){
 				if (d.getUTCFullYear() === year)


### PR DESCRIPTION
With the templating system, we are now able to define the left and right arrows.  Users may end up using font icons that typically follow the common empty span with icon class name: `<span class="icon-right-arrow"></span>`.

While the font icons show as expected, they are being prematurely selected by jQuery since the code assumes only span elements will only exist for the month listing and not the next/prev arrows which by default are characters.  You can replicate this by selecting a date in the below jsfiddle, and then clicking on the month name to enter the month listing.  You will see that the active class incorrectly applies itself two months before the actual active month.  A similar (same?) issue appeared on the original bootstrap-datepicker https://github.com/smalot/bootstrap-datetimepicker/issues/277

https://jsfiddle.net/rgjsq9bL/

All I've done was retarget the troubled selector to only look for span elements within tbody.