### PR TITLE
Fix bug when clicking on a day that is highlighted today in the next month.

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -1232,7 +1232,7 @@
 			}
 
 			// Clicked on today button
-			if (target.hasClass('today')){
+			if (target.hasClass('today') && !target.hasClass('day')){
 				this.showMode(-2);
 				this._setDate(UTCToday(), this.o.todayBtn === 'linked' ? null : 'view');
 			}

--- a/tests/suites/mouse_navigation/2012.js
+++ b/tests/suites/mouse_navigation/2012.js
@@ -249,3 +249,18 @@ test('Selecting date from next month resets viewDate and date, changing month di
     target = this.picker.find('.datepicker-days tbody td:first');
     equal(target.text(), '29'); // Should be Apr 29
 });
+
+test('Selecting today from next month', patch_date(function(Date){
+    var target;
+    this.dp.o.todayHighlight = true;
+    Date.now = new Date(2012, 2, 3); // Mar 3
+    this.input.val('01-02-2012');    // Feb 1
+    this.dp.update();
+
+    // Click the today button
+    target = this.picker.find('.datepicker-days tbody td.today');
+    equal(target.text(), '3'); // Should be Mar 3
+    target.click();
+
+    datesEqual(this.dp.viewDate, UTCDate(2012, 2, 3));
+}));


### PR DESCRIPTION
When the date picker is in `days` mode, and the current day is in the next month, and it is clicked, the wrong month is chosen.

![image](https://cloud.githubusercontent.com/assets/643885/14993791/658b61b6-1121-11e6-98a2-b4a5ece25f7c.png)

Clicking the highlighted `3` there results in the date picked below.

![image](https://cloud.githubusercontent.com/assets/643885/14993830/9859977a-1121-11e6-8f74-14d06ef74cf0.png)

I think this is happening because there is code written to handle clicking on the large `today` button that is also being run on the highlighted `today` day of the month. This PR prevents that code from running when clicking on the highlighted `today` day of the month, so it is treated like any other day.