### PR TITLE
Mousedown event rework - Fix for #1876

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -334,6 +334,7 @@
 				o.defaultViewDate = UTCToday();
 			}
 		},
+		_mousedown_target: null,
 		_events: [],
 		_secondaryEvents: [],
 		_applyEvents: function(evs){
@@ -412,6 +413,21 @@
 					blur: $.proxy(function(e){
 						this._focused_from = e.target;
 					}, this)
+				}],
+				// Input: listen for focusout on element
+				[this.element, {
+					focusout: $.proxy(function(){
+						if (!(
+								this.element.is(this._mousedown_target) ||
+								this.element.find(this._mousedown_target).length ||
+								this.picker.is(this._mousedown_target) ||
+								this.picker.find(this._mousedown_target).length ||
+								this.isInline
+							)) {
+							this.hide();
+						}
+						this._mousedown_target = null;
+					}, this)
 				}]
 			);
 
@@ -433,16 +449,8 @@
 				}],
 				[$(document), {
 					mousedown: $.proxy(function(e){
-						// Clicked outside the datepicker, hide it
-						if (!(
-							this.element.is(e.target) ||
-							this.element.find(e.target).length ||
-							this.picker.is(e.target) ||
-							this.picker.find(e.target).length ||
-							this.isInline
-						)){
-							this.hide();
-						}
+						this._mousedown_target = e.target;
+						setTimeout(this._clearMouseDownTarget, 100);
 					}, this)
 				}]
 			];
@@ -483,6 +491,9 @@
 					return DPGlobal.formatDate(date, format, this.o.language);
 				}, this)
 			});
+		},
+		_clearMouseDownTarget: function () {
+			this._mousedown_target = null;
 		},
 
 		show: function(){


### PR DESCRIPTION
This should be a good fix for the issue #1876.
The idea is to store on which element the `mousedown` event and then wait for the `focusout` event to be fired, and only then test whenever the input lost focus for the picker or not.