### PR TITLE
Issue #1876

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -513,7 +513,7 @@
 			if (this.o.forceParse && this.inputField.val())
 				this.setValue();
 			this._trigger('hide');
-			this.inputField.blur();
+			$(this.element).blur();
 			return this;
 		},
 

--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -513,6 +513,7 @@
 			if (this.o.forceParse && this.inputField.val())
 				this.setValue();
 			this._trigger('hide');
+			this.inputField.blur();
 			return this;
 		},
 


### PR DESCRIPTION
My approach is to just blur the element every time we hide the picker. Feels a little scorched earth, but it definitely fixes the issue and doesn't change any user experience(the focusout event would've happened anyway). 

I can't think of a way to write a test for this though. I think the existing tests should cover it. 