### PR TITLE
keepEmptyValues followup

### DIFF
--- a/docs/options.rst
+++ b/docs/options.rst
@@ -284,14 +284,6 @@ Boolean. Default: false
 If true, selecting a year or month in the datepicker will update the input value immediately. Otherwise, only selecting a day of the month will update the input value immediately.
 
 
-keepEmptyValues
----------------
-
-Boolean. Default: false
-
-Only effective in a range picker. If true, the selected value does not get propagated to other, currently empty, pickers in the range.
-
-
 inputs
 ------
 
@@ -311,6 +303,14 @@ A list of inputs to be used in a range picker, which will be attached to the sel
     $('#event_period').datepicker({
         inputs: $('.actual_range')
     });
+
+
+keepEmptyValues
+---------------
+
+Boolean. Default: false
+
+Only effective in a range picker. If true, the selected value does not get propagated to other, currently empty, pickers in the range.
 
 
 keyboardNavigation
@@ -519,6 +519,7 @@ assumeNearbyYear             false
 format                       'mm/dd/yyyy'
 immediateUpdates             false
 inputs
+keepEmptyValues              false
 keyboardNavigation           true
 language                     'en'
 maxViewMode                  4 'centuries'

--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -1581,7 +1581,7 @@
 		});
 		delete options.inputs;
 
-		this.keepEmptyValues = options.keepEmptyValues || false;
+		this.keepEmptyValues = options.keepEmptyValues;
 		delete options.keepEmptyValues;
 
 		datepickerPlugin.call($(this.inputs), options)
@@ -1755,6 +1755,7 @@
 		endDate: Infinity,
 		forceParse: true,
 		format: 'mm/dd/yyyy',
+		keepEmptyValues: false,
 		keyboardNavigation: true,
 		language: 'en',
 		minViewMode: 0,

--- a/tests/suites/options.js
+++ b/tests/suites/options.js
@@ -1515,29 +1515,35 @@ test('date cells', function(){
 
 test('keepEmptyValues: none (default is false)', function() {
     var proxy_element = $('<div />').appendTo('#qunit-fixture'),
-        input_from = $('<input />').appendTo('#qunit-fixture'),
+        input_from = $('<input />').val('2016-04-01').appendTo('#qunit-fixture'),
         input_to = $('<input />').appendTo('#qunit-fixture'),
         dp = proxy_element.datepicker({
+            format: 'yyyy-mm-dd',
             inputs: [input_from, input_to]
-        });
+        }),
+        input_from_dp = input_from.data('datepicker');
 
-    input_from.val('2012-03-05');
-    input_from.datepicker('setValue');
+    input_from.focus();
+    input_from_dp.picker.find('.old.day').eq(0).click();
 
-    equal(input_to.val(), input_from.val(), 'Input_from value should be distributed.');
+    equal(input_from.val(), '2016-03-27');
+    equal(input_to.val(), '2016-03-27', 'Input_from value should be distributed.');
 });
 
 test('keepEmptyValues: true', function() {
     var proxy_element = $('<div />').appendTo('#qunit-fixture'),
-        input_from = $('<input />').appendTo('#qunit-fixture'),
+        input_from = $('<input />').val('2016-04-01').appendTo('#qunit-fixture'),
         input_to = $('<input />').appendTo('#qunit-fixture'),
         dp = proxy_element.datepicker({
+            format: 'yyyy-mm-dd',
             inputs: [input_from, input_to],
             keepEmptyValues: true
-        });
+        }),
+        input_from_dp = input_from.data('datepicker');
 
-    input_from.val('2012-03-05');
-    input_from.datepicker('setValue');
+    input_from.focus();
+    input_from_dp.picker.find('.old.day').eq(0).click();
 
-    equal(input_to.val(), '', 'Input_from value should NOT be distributed.');
+    equal(input_from.val(), '2016-03-27');
+    equal(input_to.val(), '', 'Input_from value should not be distributed.');
 });


### PR DESCRIPTION
Hi.

I moved keepEmptyValues documentation to correct alphabetical position,
added keepEmptyValues to quick reference table,
added keepEmptyValues to defaults array and
fixed tests

as suggested by comments of @acrobat in #1558 