### PR TITLE
Fix: Close datepicker on touchstart

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -420,7 +420,7 @@
 					resize: $.proxy(this.place, this)
 				}],
 				[$(document), {
-					mousedown: $.proxy(function(e){
+					'mousedown touchstart': $.proxy(function(e){
 						// Clicked outside the datepicker, hide it
 						if (!(
 							this.element.is(e.target) ||

--- a/tests/suites/touch_navigation/all.js
+++ b/tests/suites/touch_navigation/all.js
@@ -1,0 +1,27 @@
+module('Touch Navigation (All)', {
+    setup: function(){
+        this.input = $('<input type="text">')
+                        .appendTo('#qunit-fixture')
+                        .datepicker({format: "dd-mm-yyyy"})
+                        .focus(); // Activate for visibility checks
+        this.dp = this.input.data('datepicker');
+        this.picker = this.dp.picker;
+    },
+    teardown: function(){
+        this.picker.remove();
+    }
+});
+
+test('Tapping outside datepicker hides datepicker', function(){
+    var $otherelement = $('<div />');
+    $('body').append($otherelement);
+
+    ok(this.picker.is(':visible'), 'Picker is visible');
+    this.input.trigger('click');
+    ok(this.picker.is(':visible'), 'Picker is still visible');
+
+    $otherelement.trigger('touchstart');
+    ok(this.picker.is(':not(:visible)'), 'Picker is hidden');
+
+    $otherelement.remove();
+});

--- a/tests/tests.html
+++ b/tests/tests.html
@@ -33,6 +33,7 @@
         <script src="suites/keyboard_navigation/all.js"></script>
         <script src="suites/keyboard_navigation/2012.js"></script>
         <script src="suites/keyboard_navigation/2011.js"></script>
+        <script src="suites/touch_navigation/all.js"></script>
         <script src="suites/component.js"></script>
         <script src="suites/events.js"></script>
         <script src="suites/options.js"></script>


### PR DESCRIPTION
It seems that when the event system was reworked, the bug closed in https://github.com/eternicode/bootstrap-datepicker/pull/223 got reintroduced. This PR fixes this.