### PR TITLE
Update bootstrap-datepicker.da.js

### DIFF
--- a/js/locales/bootstrap-datepicker.da.js
+++ b/js/locales/bootstrap-datepicker.da.js
@@ -11,6 +11,8 @@
 		months: ["januar", "februar", "marts", "april", "maj", "juni", "juli", "august", "september", "oktober", "november", "december"],
 		monthsShort: ["jan", "feb", "mar", "apr", "maj", "jun", "jul", "aug", "sep", "okt", "nov", "dec"],
 		today: "I Dag",
-		clear: "Nulstil"
+		clear: "Nulstil",
+    weekStart: 1,
+    format: "dd-mm-yyyy"
 	};
 }(jQuery));


### PR DESCRIPTION
Denmark starts weeks on Monday.

Format changed to correspond to danish locale:
http://sproget.dk/raad-og-regler/artikler-mv/svarbase/SV00000046
This also aligns with dotnet/windows locale.