### PR TITLE
Fix data-date-dates-disabled attribute to accept a comma-separated list

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -272,9 +272,7 @@
 
 			o.datesDisabled = o.datesDisabled||[];
 			if (!$.isArray(o.datesDisabled)) {
-				o.datesDisabled = [
-					o.datesDisabled
-				];
+				o.datesDisabled = o.datesDisabled.split(',');
 			}
 			o.datesDisabled = $.map(o.datesDisabled, function(d){
 				return DPGlobal.parseDate(d, format, o.language, o.assumeNearbyYear);

--- a/tests/suites/options.js
+++ b/tests/suites/options.js
@@ -710,6 +710,35 @@ test('DatesDisabled', function(){
     ok(!target.hasClass('disabled'), 'Day of week is enabled');
 });
 
+test('DatesDisabled as attribute', function(){
+    var input = $('<input data-date-dates-disabled="2012-10-1,2012-10-10,2012-10-20" />')
+                .appendTo('#qunit-fixture')
+                .val('2012-10-26')
+                .datepicker({
+                    format: 'yyyy-mm-dd'
+                }),
+        dp = input.data('datepicker'),
+        picker = dp.picker,
+        target;
+
+    input.focus();
+    target = picker.find('.datepicker-days tbody td:nth(1)');
+    ok(target.hasClass('disabled'), 'Day of week is disabled');
+    ok(target.hasClass('disabled-date'), 'Date is disabled');
+    target = picker.find('.datepicker-days tbody td:nth(2)');
+    ok(!target.hasClass('disabled'), 'Day of week is enabled');
+    target = picker.find('.datepicker-days tbody td:nth(10)');
+    ok(target.hasClass('disabled'), 'Day of week is disabled');
+    ok(target.hasClass('disabled-date'), 'Date is disabled');
+    target = picker.find('.datepicker-days tbody td:nth(11)');
+    ok(!target.hasClass('disabled'), 'Day of week is enabled');
+    target = picker.find('.datepicker-days tbody td:nth(20)');
+    ok(target.hasClass('disabled'), 'Day of week is disabled');
+    ok(target.hasClass('disabled-date'), 'Date is disabled');
+    target = picker.find('.datepicker-days tbody td:nth(21)');
+    ok(!target.hasClass('disabled'), 'Day of week is enabled');
+});
+
 test('BeforeShowDay', function(){
 
     var beforeShowDay = function(date) {


### PR DESCRIPTION
Setting multiple datesDisabled through a data attribute is currently broken, because the _process_options function assumes that if that value is not already an array it is only one datestring. This is not always the case; if you try to pass multiple dates to the data-date-dates-disabled attribute they will be interpreted as one long string and fail to parse as dates. Fixed by calling `.split(',')` on the raw value. Strings without commas will simply be wrapped in an array, which is the current behavior.