### PR TITLE
added "changeViewMode" event; also adds the current `viewMode` to events

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -1119,7 +1119,6 @@
 				month = d.getUTCMonth(),
 				prevState,
 				nextState;
-			this._trigger('changeViewMode', d);
 			switch (this.viewMode){
 				case 0:
 					prevState = (
@@ -1485,6 +1484,7 @@
 				.filter('.datepicker-' + DPGlobal.viewModes[this.viewMode].clsName)
 					.show();
 			this.updateNavArrows();
+      this._trigger('changeViewMode', new Date(this.viewDate));
 		}
 	};
 

--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -454,6 +454,7 @@
 			this.element.trigger({
 				type: event,
 				date: local_date,
+				viewMode: this.viewMode,
 				dates: $.map(this.dates, this._utc_to_local),
 				format: $.proxy(function(ix, format){
 					if (arguments.length === 0){
@@ -1118,6 +1119,7 @@
 				month = d.getUTCMonth(),
 				prevState,
 				nextState;
+			this._trigger('changeViewMode', d);
 			switch (this.viewMode){
 				case 0:
 					prevState = (

--- a/tests/suites/events.js
+++ b/tests/suites/events.js
@@ -445,3 +445,37 @@ test('Selecting date from next month in december triggers changeMonth/changeYear
     equal(triggeredM, 1);
     equal(triggeredY, 1);
 });
+
+test('Changing view mode triggers changeViewMode', function () {
+  var viewMode = -1,
+    triggered = 0;
+
+  this.input.val('22-07-2016');
+  this.dp.update();
+
+  this.input.on('changeViewMode', function (e) {
+    viewMode = e.viewMode;
+    triggered++;
+  });
+
+  // change from days to months
+  this.picker.find('.datepicker-days .datepicker-switch').click();
+  equal(triggered, 1);
+  equal(viewMode, 1);
+
+  // change from months to years
+  this.picker.find('.datepicker-months .datepicker-switch').click();
+  equal(triggered, 2);
+  equal(viewMode, 2);
+
+  // change from years to decade
+  this.picker.find('.datepicker-years .datepicker-switch').click();
+  equal(triggered, 3);
+  equal(viewMode, 3);
+
+  // change from decades to centuries
+  this.picker.find('.datepicker-decades .datepicker-switch').click();
+  equal(triggered, 4);
+  equal(viewMode, 4);
+
+});


### PR DESCRIPTION
Adds a "changeViewMode" event (triggered by navArrowsClick). Also adds the current `viewMode` to any triggered events.

So now you can watch `changeViewMode` and depending on the `event.viewMode` and the `event.date` you can do something..

The reasoning was that on a `viewMode` change I wanted to be able to get dates by viewMode range from a backend and then redraw the component ...

