### PR TITLE
Remove listen `changeDate` after destroy DateRangePicker

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -1567,6 +1567,7 @@
 		},
 		destroy: function(){
 			$.map(this.pickers, function(p){ p.destroy(); });
+			$(this.inputs).off('changeDate', this.dateUpdated);
 			delete this.element.data().datepicker;
 		},
 		remove: alias('destroy')


### PR DESCRIPTION
Need for correct recreate DateRangePicker on same inputs.