### PR TITLE
adds `updateViewDate` option

### DIFF
--- a/docs/options.rst
+++ b/docs/options.rst
@@ -470,6 +470,17 @@ Boolean. Default: false
 If true, selecting the currently active date in the datepicker will unset the respective date. This option is always true when the multidate option is being used.
 
 
+updateViewDate
+--------------
+
+Boolean. Default: true
+
+If false viewDate is set according to `value` on initialization and updated
+* if a day in last oder next month is selected or
+* if dates are changed by `setDate`, `setDates`, `setUTCDate` and `setUTCDates` methods.
+If `multidate` option is `true` the last selected date or the last date in array
+passed to `setDates` or `setUTCDates` is used.
+
 weekStart
 ---------
 

--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -770,14 +770,16 @@
 			}, this), true);
 			this.dates.replace(dates);
 
-			if (this.dates.length)
-				this.viewDate = new Date(this.dates.get(-1));
-			else if (this.viewDate < this.o.startDate)
-				this.viewDate = new Date(this.o.startDate);
-			else if (this.viewDate > this.o.endDate)
-				this.viewDate = new Date(this.o.endDate);
-			else
-				this.viewDate = this.o.defaultViewDate;
+			if (this.o.updateViewDate) {
+				if (this.dates.length)
+					this.viewDate = new Date(this.dates.get(-1));
+				else if (this.viewDate < this.o.startDate)
+					this.viewDate = new Date(this.o.startDate);
+				else if (this.viewDate > this.o.endDate)
+					this.viewDate = new Date(this.o.endDate);
+				else
+					this.viewDate = this.o.defaultViewDate;
+			}
 
 			if (fromArgs){
 				// setting date by clicking
@@ -1193,9 +1195,13 @@
 						month = (month + dir + 12) % 12;
 						if ((dir === -1 && month === 11) || (dir === 1 && month === 0)) {
 							year += dir;
-							this._trigger('changeYear', this.viewDate);
+							if (this.o.updateViewDate) {
+								this._trigger('changeYear', this.viewDate);
+							}
 						}
-						this._trigger('changeMonth', this.viewDate);
+						if (this.o.updateViewDate) {
+							this._trigger('changeMonth', this.viewDate);
+						}
 					}
 					this._setDate(UTCDate(year, month, day));
 				}
@@ -1273,7 +1279,7 @@
 		_setDate: function(date, which){
 			if (!which || which === 'date')
 				this._toggle_multidate(date && new Date(date));
-			if (!which || which === 'view')
+			if ((!which && this.o.updateViewDate) || which === 'view')
 				this.viewDate = date && new Date(date);
 
 			this.fill();
@@ -1688,6 +1694,7 @@
 		startView: 0,
 		todayBtn: false,
 		todayHighlight: false,
+		updateViewDate: true,
 		weekStart: 0,
 		disableTouchKeyboard: false,
 		enableOnReadonly: true,

--- a/tests/suites/options.js
+++ b/tests/suites/options.js
@@ -1612,3 +1612,46 @@ test('maxViewMode and navigation switch', function(){
     picker.find('.datepicker-days thead th.datepicker-switch').click();
     ok(picker.find('.datepicker-days').is(':visible'), 'Days view visible');
 });
+
+test('updateViewDate', function() {
+    expect(8);
+
+    var input = $('<input value="08/03/1990"/>')
+                .appendTo('#qunit-fixture')
+                .datepicker({
+                  defaultViewDate: {
+                    year: 1945,
+                    month: 4,
+                    day: 8
+                  },
+                  updateViewDate: false
+                })
+                .on('changeMonth', function() {
+                  var msg = shouldTriggerChangeMonth ? 'changeMonth must be triggered' : 'changeMonth must not be triggered';
+                  ok(shouldTriggerChangeMonth, msg);
+                })
+                .on('changeYear', function() {
+                  var msg = shouldTriggerChangeYear ? 'changeYear must be triggered' : 'changeYear must not be triggered';
+                  ok(shouldTriggerChangeYear, msg);
+                }),
+        dp = input.data('datepicker'),
+        picker = dp.picker,
+        shouldTriggerChangeMonth = false,
+        shouldTriggerChangeYear = false,
+        monthShown = picker.find('.datepicker-days thead th.datepicker-switch');
+
+    equal(monthShown.text(), "May 1945", 'uses defaultViewDate on initialization');
+    input.datepicker('setDate', new Date(1945, 8, 2));
+    equal(monthShown.text(), "May 1945", 'does not change viewDate on `setDate` method');
+    input.focus();
+    picker.find('.datepicker-days tbody tr td.day.new:first').click();
+    equal(monthShown.text(), "May 1945", 'does not change viewDate if a day in next month is selected');
+    shouldTriggerChangeMonth = true;
+    picker.find('.datepicker-days thead th.next').click();
+    equal(monthShown.text(), 'June 1945', 'changing month must still be possible'); // and must trigger `changeMonth` event
+    shouldTriggerChangeYear = true;
+    picker.find('.datepicker-days thead th.datepicker-switch').click();
+    picker.find('.datepicker-months thead th.next').click();
+    picker.find('.datepicker-months tbody .month:first').click();
+    equal(monthShown.text(), 'January 1946', 'changing year must still be possible'); // and must trigger `changeYear` and `changeMonth` events
+});


### PR DESCRIPTION
Implementation details are present in updated docs and added test. Default value does not change any existing behaviour.

I think this option will be helpful if you interact with bootstrap-datepicker via code. It allows you a more granular control how bootstrap-datepicker reacts on changes. It will be really powerful together with `setViewDate` method suggested in #1978.

Please have a review on syntax used in docs. I'm not quite sure if lists are supported and wasn't able to build docs to verify.