### PR TITLE
Fix keepEmptyValues when inverting range edge

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -1563,12 +1563,18 @@
 			if (new_date < this.dates[j]){
 				// Date being moved earlier/left
 				while (j >= 0 && new_date < this.dates[j]){
-					this.pickers[j--].setUTCDate(new_date);
+					var earlier_picker = this.pickers[j--];
+
+					if (!keep_empty_values || earlier_picker.getUTCDate())
+						earlier_picker.setUTCDate(new_date);
 				}
 			} else if (new_date > this.dates[k]){
 				// Date being moved later/right
 				while (k < l && new_date > this.dates[k]){
-					this.pickers[k++].setUTCDate(new_date);
+					var later_picker = this.pickers[k++];
+
+					if (!keep_empty_values || later_picker.getUTCDate())
+						later_picker.setUTCDate(new_date);
 				}
 			}
 			this.updateDates();

--- a/tests/suites/options.js
+++ b/tests/suites/options.js
@@ -1598,6 +1598,24 @@ test('keepEmptyValues: true', function() {
     equal(input_to.val(), '', 'Input_from value should not be distributed.');
 });
 
+test('keepEmptyValues: true when choosing an earlier "to" date', function() {
+    var proxy_element = $('<div />').appendTo('#qunit-fixture'),
+        input_from = $('<input />').appendTo('#qunit-fixture'),
+        input_to = $('<input />').val('2016-04-01').appendTo('#qunit-fixture'),
+        dp = proxy_element.datepicker({
+          format: 'yyyy-mm-dd',
+          inputs: [input_from, input_to],
+          keepEmptyValues: true
+        }),
+        input_to_dp = input_to.data('datepicker');
+
+    input_to.focus();
+    input_to_dp.picker.find('.old.day').eq(0).click();
+
+    equal(input_from.val(), '', 'Input_to value should not be distributed.');
+    equal(input_to.val(), '2016-03-27');
+});
+
 test('maxViewMode and navigation switch', function(){
     var input = $('<input />')
                 .appendTo('#qunit-fixture')


### PR DESCRIPTION
When selecting a new "to" date earlier than the currently selected "to"
date, `keepEmptyValues` was not being respected. This update checks that
`keepEmptyValues` is `false` before overwriting empty values.

In my experience, it did not seem to affect the "from" field, but I changed it to be safe.