### PR TITLE
resolves bug on days when DST is added.

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -533,7 +533,7 @@
 
 			var local = new Date(utc.getTime() + (utc.getTimezoneOffset() * 60000));
 
-			if (local.getTimezoneOffset() != utc.getTimezoneOffset())
+			if (local.getTimezoneOffset() !== utc.getTimezoneOffset())
 			{
 				local = new Date(utc.getTime() + (local.getTimezoneOffset() * 60000));
 			}

--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -529,7 +529,10 @@
 
 		_utc_to_local: function(utc){
 
-			if (!utc) return utc;
+			if (!utc)
+			{
+				return utc;
+			}
 
 			var local = new Date(utc.getTime() + (utc.getTimezoneOffset() * 60000));
 

--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -528,7 +528,17 @@
 		},
 
 		_utc_to_local: function(utc){
-			return utc && new Date(utc.getTime() + (utc.getTimezoneOffset()*60000));
+
+			if (!utc) return utc;
+
+			var local = new Date(utc.getTime() + (utc.getTimezoneOffset() * 60000));
+
+			if (local.getTimezoneOffset() != utc.getTimezoneOffset())
+			{
+				local = new Date(utc.getTime() + (local.getTimezoneOffset() * 60000));
+			}
+
+			return utc && local;
 		},
 		_local_to_utc: function(local){
 			return local && new Date(local.getTime() - (local.getTimezoneOffset()*60000));

--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -528,20 +528,17 @@
 		},
 
 		_utc_to_local: function(utc){
-
-			if (!utc)
-			{
+			if (!utc) {
 				return utc;
 			}
 
 			var local = new Date(utc.getTime() + (utc.getTimezoneOffset() * 60000));
 
-			if (local.getTimezoneOffset() !== utc.getTimezoneOffset())
-			{
+			if (local.getTimezoneOffset() !== utc.getTimezoneOffset()) {
 				local = new Date(utc.getTime() + (local.getTimezoneOffset() * 60000));
 			}
 
-			return utc && local;
+			return local;
 		},
 		_local_to_utc: function(local){
 			return local && new Date(local.getTime() - (local.getTimezoneOffset()*60000));


### PR DESCRIPTION
On days when DST is added this results in getDate call returning the incorrect day. 

As an example on October 2, 2016 many parts of Australia move from AEST to AEDT.  Clicking on October 2, 2016 and then triggering datepicker('getDate') results in October 1, 2016 being returned.

Here is a JSFiddle demonstrating the issue (with instructions): https://jsfiddle.net/kylethielk/x6eafu3g/

Here is a JSFiddle with my proposed changes that resolve the issue:
https://jsfiddle.net/kylethielk/aea7jobw/2/

Let me know if you have any questions.