### PR TITLE
"rangeTwoInputs" mode added

### DIFF
--- a/docs/options.rst
+++ b/docs/options.rst
@@ -385,6 +385,13 @@ A space-separated string consisting of one or two of "left" or "right", "top" or
 "auto" triggers "smart orientation" of the picker.  Horizontal orientation will default to "left" and left offset will be tweaked to keep the picker inside the browser viewport; vertical orientation will simply choose "top" or "bottom", whichever will show more of the picker in the viewport.
 
 
+rangeTwoInputs
+--------------
+
+Boolean. Default: false
+
+If true, datepicker switched to special mode in which user may choose range and start will always be displayed in first input while end in the second. You *always* exactly 2 inputs to make this mode work. If you use date range then give this mode  try.
+
 showOnFocus
 -----------
 

--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -1504,6 +1504,11 @@
 		this.inputs = $.map(options.inputs, function(i){
 			return i.jquery ? i[0] : i;
 		});
+		if (options.rangeTwoInputs && options.inputs.length != 2) {
+			throw new Error("rangeTwoInputs needs 2 inputs");
+		}
+		this.rangeTwoInputs = options.rangeTwoInputs;
+
 		delete options.inputs;
 
 		this.keepEmptyValues = options.keepEmptyValues;
@@ -1555,22 +1560,35 @@
 			if (i === -1)
 				return;
 
-			$.each(this.pickers, function(i, p){
-				if (!p.getUTCDate() && (p === dp || !keep_empty_values))
-					p.setUTCDate(new_date);
-			});
+				if (this.rangeTwoInputs) {
+					// Take minimum from pickers
+					if (new_date < this.dates[0]) {
+						// Set first, first move to second
+						this.pickers[0].setUTCDate(new_date);
+						this.pickers[1].setUTCDate(this.dates[0]);
+					} else if(new_date > this.dates[1] || !this.dates[1]) {
+						//Set second, first move 1
+						this.pickers[1].setUTCDate(new_date);
+						this.pickers[0].setUTCDate(this.dates[0]);
+					}
+				} else {
+					$.each(this.pickers, function(i, p){
+						if (!p.getUTCDate() && (p === dp || !keep_empty_values))
+							p.setUTCDate(new_date);
+					});
 
-			if (new_date < this.dates[j]){
-				// Date being moved earlier/left
-				while (j >= 0 && new_date < this.dates[j]){
-					this.pickers[j--].setUTCDate(new_date);
+					if (new_date < this.dates[j]){
+						// Date being moved earlier/left
+						while (j >= 0 && new_date < this.dates[j]){
+							this.pickers[j--].setUTCDate(new_date);
+						}
+					} else if (new_date > this.dates[k]){
+						// Date being moved later/right
+						while (k < l && new_date > this.dates[k]){
+							this.pickers[k++].setUTCDate(new_date);
+						}
+					}
 				}
-			} else if (new_date > this.dates[k]){
-				// Date being moved later/right
-				while (k < l && new_date > this.dates[k]){
-					this.pickers[k++].setUTCDate(new_date);
-				}
-			}
 			this.updateDates();
 
 			delete this.updating;

--- a/tests/suites/options.js
+++ b/tests/suites/options.js
@@ -1612,3 +1612,25 @@ test('maxViewMode and navigation switch', function(){
     picker.find('.datepicker-days thead th.datepicker-switch').click();
     ok(picker.find('.datepicker-days').is(':visible'), 'Days view visible');
 });
+
+test('rangeTwoInputs mode: click 10, 15 and check 10-15 range selected', function() {
+  var pickerJQ =$(
+		'<div class="input-group input-daterange" id="datepicker">' +
+			'<input type="text" class="form-control" id="start">' +
+			'<span class="input-group-addon">to</span>' +
+			'<input type="text" class="form-control">' +
+		'</div>')
+		.appendTo('#qunit-fixture')
+		.datepicker({
+			rangeTwoInputs: true
+		});
+  var pickerRangeObject = pickerJQ.data("datepicker");
+  var firstInputJQ = $(pickerRangeObject.inputs[0]);
+  firstInputJQ.focus();
+  var firstPickerObject = pickerRangeObject.pickers[0];
+  var firstPickerJQ = firstPickerObject.picker;
+  firstPickerJQ.find('td.day:contains("10")').click();
+  firstPickerJQ.find('td.day:contains("15")').click();
+  firstPickerJQ.find('td.range').html();
+  ok("11121314" == firstPickerJQ.find('td.range').text(), "Wrong range selected");
+});


### PR DESCRIPTION
Hi. This feature I did for my own project, but I want to share it with you.
You can read doc, but here is how it works: 
* User inserts 2 inputs and provides ``rangeTwoInputs`` option
* Client may click any input and then choose first date. First date always goes to first input. Then, second date should be chosen which goes to second input. So, there is a range which is displayed visually. 

Please note this is *not* how it works in your version. Try to click on first input, choose first date and then choose second. Instead of range, second date is copied to both fields. I am note sure if it is bug or feature, but ``rangeTwoInputs`` looks cleaner for me.

Thank you for your datepicker)